### PR TITLE
feature/asserting-config-paths-exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(Ceres REQUIRED)
 # boost related setup
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost REQUIRED log)
+find_package(Boost COMPONENTS log system filesystem REQUIRED)
 message(STATUS "Boost version: ${Boost_VERSION}")
 
 # This is needed if your Boost version is newer than your CMake version
@@ -73,14 +73,14 @@ list(REMOVE_ITEM MC_CALIB_SRC ${PROJECT_SOURCE_DIR}/src/main_calibrate.cpp ${PRO
 add_executable(calibrate src/main_calibrate.cpp ${MC_CALIB_SRC})
 
 target_link_libraries(calibrate
- -L/usr/local/lib ${OpenCV_LIBS} ${CERES_LIBRARIES} Boost::log
+ -L/usr/local/lib ${OpenCV_LIBS} ${CERES_LIBRARIES} Boost::log Boost::system Boost::filesystem 
  )
 
 ##################Generate Charuco######################
 add_executable(generate_charuco src/main_create_charuco.cpp)
 
 target_link_libraries(generate_charuco
- -L/usr/local/lib ${OpenCV_LIBS} ${CERES_LIBRARIES} Boost::log
+ -L/usr/local/lib ${OpenCV_LIBS} ${CERES_LIBRARIES} Boost::log Boost::system Boost::filesystem
  )
 
 # unit tests related

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,3 +1,4 @@
+#include "boost/filesystem.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
 #include <numeric>
@@ -21,6 +22,12 @@ Board::Board(const std::string config_path, const int board_idx) {
   std::vector<int> boards_index;
   int nb_board;
   cv::FileStorage fs; // FileStorage object to read calibration params from file
+  const bool is_file_available =
+      boost::filesystem::exists(config_path) && config_path.length() > 0;
+  if (!is_file_available) {
+    LOG_FATAL << "Config path '" << config_path << "' doesn't exist.";
+    return;
+  }
   fs.open(config_path, cv::FileStorage::READ);
   fs["number_board"] >> nb_board;
   fs["number_x_square_per_board"] >> number_x_square_per_board;

--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -21,6 +21,12 @@ Calibration::Calibration(const std::string config_path) {
   std::vector<int> boards_index;
   int nb_x_square, nb_y_square;
   float length_square, length_marker;
+  const bool is_file_available =
+      boost::filesystem::exists(config_path) && config_path.length() > 0;
+  if (!is_file_available) {
+    LOG_FATAL << "Config path '" << config_path << "' doesn't exist.";
+    return;
+  }
   fs.open(config_path, cv::FileStorage::READ);
   fs["number_camera"] >> nb_camera_;
   fs["number_board"] >> nb_board_;
@@ -480,6 +486,14 @@ void Calibration::insertNewObjectObservation(
 void Calibration::initializeCalibrationAllCam() {
   if (!cam_params_path_.empty() && cam_params_path_ != "None") {
     cv::FileStorage fs;
+    const bool is_file_available =
+        boost::filesystem::exists(cam_params_path_) &&
+        cam_params_path_.length() > 0;
+    if (!is_file_available) {
+      LOG_FATAL << "Camera parameters path '" << cam_params_path_
+                << "' doesn't exist.";
+      return;
+    }
     fs.open(cam_params_path_, cv::FileStorage::READ);
 
     LOG_INFO << "Initializing camera calibration from " << cam_params_path_;

--- a/src/main_calibrate.cpp
+++ b/src/main_calibrate.cpp
@@ -90,7 +90,12 @@ void runCalibrationWorkflow(std::string config_path) {
 
 int main(int argc, char *argv[]) {
   std::string config_path = argv[1];
-
+  const bool is_file_available =
+      boost::filesystem::exists(config_path) && config_path.length() > 0;
+  if (!is_file_available) {
+    LOG_FATAL << "Config path '" << config_path << "' doesn't exist.";
+    return -1;
+  }
   runCalibrationWorkflow(config_path);
 
   return 0;

--- a/src/main_create_charuco.cpp
+++ b/src/main_create_charuco.cpp
@@ -1,3 +1,4 @@
+#include "boost/filesystem.hpp"
 #include <iomanip>
 #include <opencv2/aruco/charuco.hpp>
 #include <opencv2/opencv.hpp>
@@ -20,6 +21,12 @@ int main(int argc, char *argv[]) {
   std::vector<int> resolution_x_per_board, resolution_y_per_board;
   std::vector<double> square_size_per_board;
   cv::FileStorage fs; // FileStorage to read calibration params from file
+  const bool is_file_available =
+      boost::filesystem::exists(pathInt) && pathInt.length() > 0;
+  if (!is_file_available) {
+    std::cout << "Config path '" << pathInt << "' doesn't exist." << std::endl;
+    return -1;
+  }
   fs.open(pathInt, cv::FileStorage::READ);
   fs["number_x_square"] >> num_x_square;
   fs["number_y_square"] >> num_y_square;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package (Boost REQUIRED COMPONENTS unit_test_framework log_setup log)
+find_package (Boost REQUIRED COMPONENTS unit_test_framework log_setup log filesystem REQUIRED)
 
 include_directories (${Boost_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src)
 


### PR DESCRIPTION
Asserting config all the relevant files -- which are being read from the disk -- exist. 

Fixes #8.