### PR TITLE
feature/docker-with-all-tools-cpp17-multithreading

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,9 @@
 * Types of cameras => ❔ (perspective, fisheye, hybrid)
 * Multicamera configurations => ❔ (overlapping, non-overlapping, converging)
 * Configuration file => ❔ (i.e. `*.yml`)
-* Image sequences => ❔ (if relevant and possible, please share image sequences)
+* Image sequences => ❔
+    - number of images per camera
+    - if relevant and possible, please share image sequences
 
 ### Describe the issue / bug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(MC-Calib)
 
-add_definitions(-std=c++14)
-set(CMAKE_CXX_FLAGS "-std=c++14") # required for Ceres https://github.com/colmap/colmap/issues/905#issuecomment-731138700
+add_definitions(-std=c++17)
+set(CMAKE_CXX_FLAGS "-std=c++17") # required for Ceres https://github.com/colmap/colmap/issues/905#issuecomment-731138700
 set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE STRING "" FORCE)
 
 find_package(OpenCV REQUIRED)
@@ -26,7 +26,9 @@ if(NOT TARGET Boost::filesystem)
         INTERFACE_LINK_LIBRARIES ${Boost_LIBRARIES})
 endif()
 
+IF(SSSE3_FOUND)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse3")
+ENDIF(SSSE3_FOUND)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 
 # sanitizers https://www.jetbrains.com/help/clion/google-sanitizers.html#Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Toolbox described in the paper ["MC-Calib: A generic and robust calibration tool
 
 # Installation
 
-Requirements: Ceres, Boost, OpenCV 4.5.x, c++14 
+Requirements: Ceres, Boost, OpenCV 4.5.x, c++17 
 
 There are several ways to get the environment ready. Choose any of them:
 
@@ -18,7 +18,8 @@ There are several ways to get the environment ready. Choose any of them:
    - Pull the image:
 
      ```bash
-     docker pull frameau/opencv-ceres
+     docker pull bailool/mc-calib-prod # production environment
+     docker pull bailool/mc-calib-dev  # development environment
      ```
 
    - Run pulled image:
@@ -33,10 +34,10 @@ There are several ways to get the environment ready. Choose any of them:
                   --env="DISPLAY" \
                   --env="QT_X11_NO_MITSHM=1" \
                   --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-                  --volume="$HOME/.Xauthority:/home/$USER/.Xauthority:rw" \
-                  --volume="${PWD}:/home/$USER/MC-Calib" \
-                  --volume="PATH_TO_DATA:/home/$USER/MC-Calib/data" \
-                  frameau/opencv-ceres
+                  --volume="$HOME/.Xauthority:/home/.Xauthority:rw" \
+                  --volume="${PWD}:/home/MC-Calib" \
+                  --volume="PATH_TO_DATA:/home/MC-Calib/data" \
+                  bailool/mc-calib-prod
       #xhost -local:root  # resetting permissions
       ```
       
@@ -47,7 +48,8 @@ There are several ways to get the environment ready. Choose any of them:
    - Create the image:
    
       ```bash
-      docker build - < Dockerfile -t SPECIFY_YOUR_NAME
+      docker build --target prod -t mc-calib-prod . # production environment
+      docker build --target dev -t mc-calib-dev .   # development environment
       ```
 
 3. Alternatively, every dependency can be installed independently without docker:
@@ -62,7 +64,7 @@ There are several ways to get the environment ready. Choose any of them:
       sudo apt install libboost-all-dev
       ```
 
-Then the following should do the job of compiling the code: 
+Then the following should do the job of compiling the code inside the `MC-Calib` root:
 
    ```bash
    mkdir build
@@ -77,7 +79,7 @@ Then the following should do the job of compiling the code:
 
 - It is also possible to generate Doxygen documentation locally:
 
-   - Install [Doxygen](https://www.doxygen.nl/download.html):
+   - Install [Doxygen](https://www.doxygen.nl/download.html) or use `mc-calib-dev` docker image:
 
       ```bash
       sudo apt install flex

--- a/src/Calibration.hpp
+++ b/src/Calibration.hpp
@@ -3,6 +3,7 @@
 #include "boost/filesystem.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
+#include <mutex>
 #include <numeric>
 #include <opencv2/aruco/charuco.hpp>
 #include <opencv2/calib3d.hpp>
@@ -138,13 +139,15 @@ public:
   Calibration(
       const std::string config_path); // initialize the charuco pattern, nb
                                       // of cameras, nb of boards etc.
+  Calibration(const Calibration &) = delete;
+  Calibration &operator=(const Calibration &) = delete;
+
   void boardExtraction();
-  void detectBoards(
-      const cv::Mat image, const int cam_idx, const int frame_idx,
-      const std::string frame_path); // detect the board in the input frame
-  void saveCamerasParams();          // Save all cameras params
-  void save3DObj();                  // Save 3D objects
-  void save3DObjPose();              // Save 3D objects pose
+  void detectBoards(const std::vector<cv::String> &fn,
+                    const int cam); // detect the boards in all images
+  void saveCamerasParams();         // Save all cameras params
+  void save3DObj();                 // Save 3D objects
+  void save3DObjPose();             // Save 3D objects pose
   void displayBoards(const cv::Mat image, const int cam_idx,
                      const int frame_idx);
   void
@@ -218,4 +221,11 @@ public:
   void saveDetection(const int cam_id);
   void saveDetectionAllCam();
   void saveReprojectionErrorToFile();
+
+private:
+  void detectBoardsInImage(
+      const std::string frame_path, const int cam_idx,
+      const int frame_idx); // detect the boards in the input frame
+
+  std::mutex insert_new_board_lock_;
 };

--- a/src/main_calibrate.cpp
+++ b/src/main_calibrate.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <iomanip>
 #include <opencv2/aruco/charuco.hpp>
 #include <opencv2/opencv.hpp>
@@ -89,14 +90,20 @@ void runCalibrationWorkflow(std::string config_path) {
 }
 
 int main(int argc, char *argv[]) {
-  std::string config_path = argv[1];
+  const std::string config_path = argv[1];
   const bool is_file_available =
       boost::filesystem::exists(config_path) && config_path.length() > 0;
   if (!is_file_available) {
     LOG_FATAL << "Config path '" << config_path << "' doesn't exist.";
     return -1;
   }
+
+  auto start = std::chrono::high_resolution_clock::now();
   runCalibrationWorkflow(config_path);
+  auto stop = std::chrono::high_resolution_clock::now();
+  auto duration =
+      std::chrono::duration_cast<std::chrono::seconds>(stop - start);
+  LOG_INFO << "Calibration took " << duration.count() << " seconds";
 
   return 0;
 }

--- a/tests/test_calibration.cpp
+++ b/tests/test_calibration.cpp
@@ -32,9 +32,8 @@ double getRotationError(cv::Mat a, cv::Mat b) {
   return rot_error;
 }
 
-Calibration calibrate(std::string config_path) {
+void calibrate(Calibration &Calib) {
   // calibrate
-  Calibration Calib(config_path);
   Calib.boardExtraction();
   Calib.initIntrinsic();
   Calib.calibrate3DObjects();
@@ -55,12 +54,11 @@ Calibration calibrate(std::string config_path) {
   if (Calib.fix_intrinsic_ == 0)
     Calib.refineAllCameraGroupAndObjectsAndIntrinsic();
   Calib.reproErrorAllCamGroup();
-
-  return Calib;
 }
 
 void calibrateAndCheckGt(std::string config_path, std::string gt_path) {
-  Calibration Calib = calibrate(config_path);
+  Calibration Calib(config_path);
+  calibrate(Calib);
 
   // read ground truth
   cv::FileStorage fs;


### PR DESCRIPTION
This PR involves:
 - New lighter dockers for production and development using build stages. The production docker image is as light as possible to download faster. The development image contains all the necessary tools for development.
 - Upgrading `CmakeLists.txt` to c++17 (though it is still back-compatible with c++14)
 - Small changes to `CmakeLists.txt` to enable running on Mac M2
 - Multithreading `detectBoards()` to calibrate faster. On M2 original calibration of `configs/Blender_Images/calib_param_synth_Scenario1.yml` took 24 seconds, and with 2 threads (returned by `std::thread::hardware_concurrency()`) - 15 seconds. Thus, 9 seconds speedup.