### PR TITLE
fix opencv init intrinsic calib

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -244,8 +244,8 @@ bool Camera::checkBorderToleranceFisheye(std::shared_ptr<BoardObs> board_obs) {
   const float thresh_border_x = float(im_cols_) * border_marging;
   const float thresh_border_y = float(im_rows_) * border_marging;
   for (int i = 0; i < board_obs->pts_2d_.size(); i++) {
-    float pt_x = board_obs->pts_2d_[i].x;
-    float pt_y = board_obs->pts_2d_[i].y;
+    const float &pt_x = board_obs->pts_2d_[i].x;
+    const float &pt_y = board_obs->pts_2d_[i].y;
     if (pt_x <= thresh_border_x || pt_x >= (im_cols_ - thresh_border_x) ||
         pt_y <= thresh_border_y || pt_y >= (im_rows_ - thresh_border_y)) {
       valid_board = false;

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -191,20 +191,9 @@ void Camera::initializeCalibration() {
         board_observations_[indbv[shuffled_board_ind[i]]].lock();
     if (board_obs_temp) {
       // if fisheye, check if points are not too close to borders
-      // bug fix opencv from
-      // https://github.com/realizator/stereopi-fisheye-robot/blob/master/4_calibration_fisheye.py
       bool valid_board = true;
       if (distortion_model_ == 1) {
-        float thresh_border_x = im_cols_ / 20;
-        float thresh_border_y = im_rows_ / 20;
-        for (int i = 0; i < board_obs_temp->pts_2d_.size(); i++) {
-          float pt_x = board_obs_temp->pts_2d_[i].x;
-          float pt_y = board_obs_temp->pts_2d_[i].y;
-          if (pt_x <= thresh_border_x || pt_x >= (im_cols_ - thresh_border_x) ||
-              pt_y <= thresh_border_y || pt_y >= (im_rows_ - thresh_border_y)) {
-            valid_board = false;
-          }
-        }
+        valid_board = checkBorderToleranceFisheye(board_obs_temp);
       }
       if (valid_board == true) {
         img_points.emplace_back(board_obs_temp->pts_2d_);
@@ -241,6 +230,30 @@ void Camera::initializeCalibration() {
 
   // Save data in the structure
   setIntrinsics(camera_matrix, distortion_coeffs);
+}
+
+
+/**
+ * @brief determine if the board is valid for the calibration
+ * of fisheye cameras
+ * bug fix opencv from:
+ * https://github.com/realizator/stereopi-fisheye-robot/blob/master/
+ * 4_calibration_fisheye.py
+ */
+bool Camera::checkBorderToleranceFisheye(std::shared_ptr<BoardObs> board_obs) {
+  bool valid_board = true;
+  const float thresh_border_x = float(im_cols_) * border_marging;
+  const float thresh_border_y = float(im_rows_) * border_marging;
+  for (int i = 0; i < board_obs->pts_2d_.size(); i++) {
+    float pt_x = board_obs->pts_2d_[i].x;
+    float pt_y = board_obs->pts_2d_[i].y;
+    if (pt_x <= thresh_border_x || pt_x >= (im_cols_ - thresh_border_x) ||
+        pt_y <= thresh_border_y || pt_y >= (im_rows_ - thresh_border_y)) {
+      valid_board = false;
+      break;
+    }
+  }
+  return valid_board;
 }
 
 /**

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -232,7 +232,6 @@ void Camera::initializeCalibration() {
   setIntrinsics(camera_matrix, distortion_coeffs);
 }
 
-
 /**
  * @brief determine if the board is valid for the calibration
  * of fisheye cameras

--- a/src/Camera.hpp
+++ b/src/Camera.hpp
@@ -22,6 +22,11 @@
  * - object observation
  */
 class Camera final {
+
+private:
+  // fisheye border margin to exclude invalid boards during initialization
+  const float border_marging = 0.05f; // border margin tolerance
+
 public:
   // datastructure for this camera
   std::map<int, std::weak_ptr<BoardObs>>
@@ -43,9 +48,6 @@ public:
 
   // camera index
   int cam_idx_;
-
-  // fisheye border margin to exclude invalid boards during initialization
-  const float border_marging = 0.05; // border margin tolerance
 
   // Functions
   Camera() = delete;

--- a/src/Camera.hpp
+++ b/src/Camera.hpp
@@ -44,6 +44,9 @@ public:
   // camera index
   int cam_idx_;
 
+  // fisheye border margin to exclude invalid boards during initialization
+  const float border_marging = 0.05; // border margin tolerance
+
   // Functions
   Camera() = delete;
   Camera(const int cam_idx, const int distortion_model);
@@ -59,4 +62,5 @@ public:
   cv::Mat getDistortionVectorVector() const;
   void getIntrinsics(cv::Mat &K, cv::Mat &distortion_vector);
   void setIntrinsics(const cv::Mat K, const cv::Mat distortion_vector);
+  bool checkBorderToleranceFisheye(std::shared_ptr<BoardObs> board_obs);
 };


### PR DESCRIPTION
Fix the bug of OpenCV fisheye camera calibration error when points are too close to image's borders.
Notes:
- This fix only affect the fisheye cameras
- The boards with corners too close to the borders are removed *only* for initialization using opencv calib but are taken into consideration properly during the remaining of the calibration process