### PR TITLE
Improved rotation vectors averaging

### DIFF
--- a/McCalib/include/CameraGroupObs.hpp
+++ b/McCalib/include/CameraGroupObs.hpp
@@ -31,10 +31,14 @@ public:
   int cam_group_idx_;
   std::weak_ptr<CameraGroup> cam_group_;
 
+  bool quaternion_averaging_ =
+      true; // use Quaternion Averaging or median for average rotation
+
   // Functions
   CameraGroupObs() = delete;
   ~CameraGroupObs();
-  CameraGroupObs(std::shared_ptr<CameraGroup> new_cam_group);
+  CameraGroupObs(std::shared_ptr<CameraGroup> new_cam_group,
+                 const bool quaternion_averaging);
   void
   insertObjectObservation(std::shared_ptr<Object3DObs> new_object_observation);
   void computeObjectsPose();

--- a/McCalib/include/McCalib.hpp
+++ b/McCalib/include/McCalib.hpp
@@ -63,6 +63,8 @@ public:
   int corner_ref_max_iter_ = 20; // max iterations for corner ref
 
   // Optimization parameters
+  bool quaternion_averaging_ =
+      true; // use Quaternion Averaging or median for average rotation
   float ransac_thresh_ = 10; // threshold in pixel
   int nb_iterations_ = 1000; // max number of iteration for refinements
 

--- a/McCalib/include/geometrytools.hpp
+++ b/McCalib/include/geometrytools.hpp
@@ -53,5 +53,7 @@ void projectPointsWithDistortion(std::vector<cv::Point3f> object_pts,
                                  std::vector<cv::Point2f> &repro_pts,
                                  int distortion_type);
 cv::Mat convertRotationMatrixToQuaternion(cv::Mat R);
-cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q);
-cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging = true);
+cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4> &q);
+cv::Mat getAverageRotation(std::vector<double> &r1, std::vector<double> &r2,
+                           std::vector<double> &r3,
+                           const bool use_quaternion_averaging = true);

--- a/McCalib/include/geometrytools.hpp
+++ b/McCalib/include/geometrytools.hpp
@@ -52,4 +52,6 @@ void projectPointsWithDistortion(std::vector<cv::Point3f> object_pts,
                                  cv::Mat distortion_vector,
                                  std::vector<cv::Point2f> &repro_pts,
                                  int distortion_type);
+cv::Mat convertRotationMatrixToQuaternion(cv::Mat R);
+cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q);
 cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging = true);

--- a/McCalib/include/geometrytools.hpp
+++ b/McCalib/include/geometrytools.hpp
@@ -52,3 +52,4 @@ void projectPointsWithDistortion(std::vector<cv::Point3f> object_pts,
                                  cv::Mat distortion_vector,
                                  std::vector<cv::Point2f> &repro_pts,
                                  int distortion_type);
+cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging = true);

--- a/McCalib/src/CameraGroupObs.cpp
+++ b/McCalib/src/CameraGroupObs.cpp
@@ -13,9 +13,11 @@
  *
  * @param new_cam_group camera group to be added
  */
-CameraGroupObs::CameraGroupObs(std::shared_ptr<CameraGroup> new_cam_group) {
+CameraGroupObs::CameraGroupObs(std::shared_ptr<CameraGroup> new_cam_group,
+                               const bool quaternion_averaging) {
   cam_group_ = new_cam_group;
   cam_group_idx_ = new_cam_group->cam_group_idx_;
+  quaternion_averaging_ = quaternion_averaging;
 }
 
 /**
@@ -89,7 +91,7 @@ void CameraGroupObs::computeObjectsPose() {
       }
       // Average version
       group_pose_t = average_translation / it_obj_obs.second.size();
-      group_pose_r = getAverageRotation(r1, r2, r3);
+      group_pose_r = getAverageRotation(r1, r2, r3, quaternion_averaging_);
     }
 
     // set the pose and update the observation

--- a/McCalib/src/CameraGroupObs.cpp
+++ b/McCalib/src/CameraGroupObs.cpp
@@ -74,19 +74,23 @@ void CameraGroupObs::computeObjectsPose() {
 
     // if the reference camera has no visible observation, then take
     // the average of other observations
-    if (flag_ref_cam == false) {
-      cv::Mat average_rotation = cv::Mat::zeros(3, 1, CV_64F);
+    if (flag_ref_cam == false) 
+    {
+      std::vector<double> r1, r2, r3;
       cv::Mat average_translation = cv::Mat::zeros(3, 1, CV_64F);
       for (const auto &obj_obs_idx : it_obj_obs.second) {
         auto obj_obs_ptr = object_observations_[obj_obs_idx].lock();
         if (obj_obs_ptr) {
-          average_rotation += obj_obs_ptr->getRotInGroupVec();
+          const cv::Mat& R = obj_obs_ptr->getRotInGroupVec();
+          r1.push_back(R.at<double>(0));
+          r2.push_back(R.at<double>(1));
+          r3.push_back(R.at<double>(2));
           average_translation += obj_obs_ptr->getTransInGroupVec();
         }
       }
       // Average version
       group_pose_t = average_translation / it_obj_obs.second.size();
-      group_pose_r = average_rotation / it_obj_obs.second.size();
+      group_pose_r = getAverageRotation(r1, r2, r3);
     }
 
     // set the pose and update the observation

--- a/McCalib/src/CameraGroupObs.cpp
+++ b/McCalib/src/CameraGroupObs.cpp
@@ -74,14 +74,13 @@ void CameraGroupObs::computeObjectsPose() {
 
     // if the reference camera has no visible observation, then take
     // the average of other observations
-    if (flag_ref_cam == false) 
-    {
+    if (flag_ref_cam == false) {
       std::vector<double> r1, r2, r3;
       cv::Mat average_translation = cv::Mat::zeros(3, 1, CV_64F);
       for (const auto &obj_obs_idx : it_obj_obs.second) {
         auto obj_obs_ptr = object_observations_[obj_obs_idx].lock();
         if (obj_obs_ptr) {
-          const cv::Mat& R = obj_obs_ptr->getRotInGroupVec();
+          const cv::Mat &R = obj_obs_ptr->getRotInGroupVec();
           r1.push_back(R.at<double>(0));
           r2.push_back(R.at<double>(1));
           r3.push_back(R.at<double>(2));

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -13,7 +13,6 @@
 #include <boost/asio/thread_pool.hpp>
 #include <thread>
 
-
 namespace McCalib {
 
 /**
@@ -767,8 +766,7 @@ void Calibration::computeBoardsPairPose() {
  */
 void Calibration::initInterTransform(
     const std::map<std::pair<int, int>, std::vector<cv::Mat>> &pose_pairs,
-    std::map<std::pair<int, int>, cv::Mat> &inter_transform) 
-{
+    std::map<std::pair<int, int>, cv::Mat> &inter_transform) {
   inter_transform.clear();
   for (const auto &it : pose_pairs) {
     const std::pair<int, int> &pair_idx = it.first;
@@ -785,8 +783,7 @@ void Calibration::initInterTransform(
     t1.reserve(num_poses);
     t2.reserve(num_poses);
     t3.reserve(num_poses);
-    for (const auto &pose_temp : poses_temp) 
-    {
+    for (const auto &pose_temp : poses_temp) {
       cv::Mat R, T;
       Proj2RT(pose_temp, R, T);
       r1.push_back(R.at<double>(0));
@@ -796,7 +793,7 @@ void Calibration::initInterTransform(
       t2.push_back(T.at<double>(1));
       t3.push_back(T.at<double>(2));
     }
-    
+
     cv::Mat average_rotation = getAverageRotation(r1, r2, r3);
     average_translation.at<double>(0) = median(t1);
     average_translation.at<double>(1) = median(t2);

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -51,6 +51,7 @@ Calibration::Calibration(const std::string config_path) {
   fs["number_y_square"] >> nb_y_square;
   fs["root_path"] >> root_dir_;
   fs["cam_prefix"] >> cam_prefix_;
+  fs["quaternion_averaging:"] >> quaternion_averaging_;
   fs["ransac_threshold"] >> ransac_thresh_;
   fs["number_iterations"] >> nb_iterations_;
   fs["distortion_model"] >> distortion_model;
@@ -794,7 +795,8 @@ void Calibration::initInterTransform(
       t3.push_back(T.at<double>(2));
     }
 
-    cv::Mat average_rotation = getAverageRotation(r1, r2, r3);
+    cv::Mat average_rotation =
+        getAverageRotation(r1, r2, r3, quaternion_averaging_);
     average_translation.at<double>(0) = median(t1);
     average_translation.at<double>(1) = median(t2);
     average_translation.at<double>(2) = median(t3);
@@ -1140,7 +1142,8 @@ void Calibration::initCameraGroupObs(const int camera_group_idx) {
     int current_frame_id = it_frame.second->frame_idx_;
     std::shared_ptr<CameraGroupObs> new_cam_group_obs =
         std::make_shared<CameraGroupObs>(
-            cam_group_[camera_group_idx]); // declare a new observation
+            cam_group_[camera_group_idx],
+            quaternion_averaging_); // declare a new observation
 
     std::map<int, std::weak_ptr<Object3DObs>> current_object_obs =
         it_frame.second->object_observations_;

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -13,6 +13,128 @@
 #include <boost/asio/thread_pool.hpp>
 #include <thread>
 
+
+namespace
+{
+
+cv::Mat convertRotationMatrixToQuaternion(cv::Mat R)
+{
+  // code is adapted from https://gist.github.com/shubh-agrawal/76754b9bfb0f4143819dbd146d15d4c8
+
+  cv::Mat Q(1, 4, CV_64F);;
+
+  double trace = R.at<double>(0,0) + R.at<double>(1,1) + R.at<double>(2,2);
+
+  if (trace > 0.0) 
+  {
+      double s = std::sqrt(trace + 1.0);
+      Q.at<double>(0, 3) = (s * 0.5);
+      s = 0.5 / s;
+      Q.at<double>(0, 0) = ((R.at<double>(2,1) - R.at<double>(1,2)) * s);
+      Q.at<double>(0, 1) = ((R.at<double>(0,2) - R.at<double>(2,0)) * s);
+      Q.at<double>(0, 2) = ((R.at<double>(1,0) - R.at<double>(0,1)) * s);
+  } 
+  
+  else 
+  {
+      int i = R.at<double>(0,0) < R.at<double>(1,1) ? (R.at<double>(1,1) < R.at<double>(2,2) ? 2 : 1) : (R.at<double>(0,0) < R.at<double>(2,2) ? 2 : 0); 
+      int j = (i + 1) % 3;  
+      int k = (i + 2) % 3;
+
+      double s = std::sqrt(R.at<double>(i, i) - R.at<double>(j,j) - R.at<double>(k,k) + 1.0);
+      Q.at<double>(0, i) = s * 0.5;
+      s = 0.5 / s;
+
+      Q.at<double>(0, 3) = (R.at<double>(k,j) - R.at<double>(j,k)) * s;
+      Q.at<double>(0, j) = (R.at<double>(j,i) + R.at<double>(i,j)) * s;
+      Q.at<double>(0, k) = (R.at<double>(k,i) + R.at<double>(i,k)) * s;
+  }
+
+  return Q;
+}
+
+cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q)
+{
+    // code adapted from https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
+
+    const double q0 = q[0];
+    const double q1 = q[1];
+    const double q2 = q[2];
+    const double q3 = q[3];
+     
+    cv::Mat rot_matrix(3, 3, CV_64F);
+    rot_matrix.at<double>(0, 0) = 2 * (q0 * q0 + q1 * q1) - 1;
+    rot_matrix.at<double>(0, 1) = 2 * (q1 * q2 - q0 * q3);
+    rot_matrix.at<double>(0, 2) = 2 * (q1 * q3 + q0 * q2);
+     
+    rot_matrix.at<double>(1, 0) = 2 * (q1 * q2 + q0 * q3);
+    rot_matrix.at<double>(1, 1) = 2 * (q0 * q0 + q2 * q2) - 1;
+    rot_matrix.at<double>(1, 2) = 2 * (q2 * q3 - q0 * q1);
+     
+    rot_matrix.at<double>(2, 0) = 2 * (q1 * q3 - q0 * q2);
+    rot_matrix.at<double>(2, 1) = 2 * (q2 * q3 + q0 * q1);
+    rot_matrix.at<double>(2, 2) = 2 * (q0 * q0 + q3 * q3) - 1;
+                            
+    return rot_matrix;
+}
+
+
+
+cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging = true)
+{
+  cv::Mat average_rotation = cv::Mat::zeros(3, 1, CV_64F);
+  if (use_quaternion_averaging)
+  {
+    // The Quaternion Averaging algorithm is described in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20070017872.pdf
+    // implementaion references:
+    //  - https://gist.github.com/PeteBlackerThe3rd/f73e9d569e29f23e8bd828d7886636a0
+    //  - https://github.com/tolgabirdal/averaging_quaternions/blob/master/avg_quaternion_markley.m
+
+    assert(r1.size() == r2.size() && r2.size() == r3.size());
+
+    std::vector<cv::Mat> quaternions;
+    // convert rotation vector to quaternion through rotation matrix
+    for (unsigned int angle_idx = 0u; angle_idx < r1.size(); ++angle_idx)
+    {
+      std::array<double, 3> angles = { r1[angle_idx], r2[angle_idx], r3[angle_idx] };
+      const cv::Mat rot_vec = cv::Mat(1, 3, CV_64F, angles.data());
+      cv::Mat rot_matrix;
+      cv::Rodrigues(rot_vec, rot_matrix);
+      const cv::Mat quaternion = convertRotationMatrixToQuaternion(rot_matrix);
+      quaternions.push_back(quaternion);
+    }
+
+    cv::Mat A = cv::Mat::zeros(4, 4, CV_64F);
+    for (const cv::Mat& q: quaternions)
+    {
+      A += q.t() * q;
+    }
+    A /= quaternions.size();
+
+    cv::SVD svd(A, cv::SVD::FULL_UV);
+    cv::Mat U = svd.u;
+    cv::Mat singularValues = svd.w;
+
+    // TODO: need to verify whether it's a row or a column vector; below treated as column vector
+    const unsigned int largestEigenValueIndex = 0u;
+    std::array<double, 4> average_quaternion = {svd.u.at<double>(0, largestEigenValueIndex), svd.u.at<double>(1, largestEigenValueIndex), 
+                                          svd.u.at<double>(2, largestEigenValueIndex), svd.u.at<double>(3, largestEigenValueIndex)};
+    cv::Mat rot_matrix = convertQuaternionToRotationMatrix(average_quaternion);
+    cv::Rodrigues(rot_matrix, average_rotation);
+  }
+  else
+  {
+    // mean reprojection error :: 0.021487
+    average_rotation.at<double>(0) = median(r1);
+    average_rotation.at<double>(1) = median(r2);
+    average_rotation.at<double>(2) = median(r3);
+  }
+
+  return average_rotation;
+}
+ 
+} // namespace
+
 namespace McCalib {
 
 /**
@@ -652,7 +774,6 @@ void Calibration::initInterTransform(
   for (const auto &it : pose_pairs) {
     const std::pair<int, int> &pair_idx = it.first;
     const std::vector<cv::Mat> &poses_temp = it.second;
-    cv::Mat average_rotation = cv::Mat::zeros(3, 1, CV_64F);
     cv::Mat average_translation = cv::Mat::zeros(3, 1, CV_64F);
 
     // Median
@@ -675,9 +796,8 @@ void Calibration::initInterTransform(
       t2.push_back(T.at<double>(1));
       t3.push_back(T.at<double>(2));
     }
-    average_rotation.at<double>(0) = median(r1);
-    average_rotation.at<double>(1) = median(r2);
-    average_rotation.at<double>(2) = median(r3);
+    
+    cv::Mat average_rotation = getAverageRotation(r1, r2, r3, true);
     average_translation.at<double>(0) = median(t1);
     average_translation.at<double>(1) = median(t2);
     average_translation.at<double>(2) = median(t3);

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -630,7 +630,7 @@ cv::Mat convertRotationMatrixToQuaternion(cv::Mat R)
 {
   // code is adapted from https://gist.github.com/shubh-agrawal/76754b9bfb0f4143819dbd146d15d4c8
 
-  cv::Mat Q(1, 4, CV_64F);;
+  cv::Mat Q(1, 4, CV_64F); // x y z w
 
   double trace = R.at<double>(0,0) + R.at<double>(1,1) + R.at<double>(2,2);
 
@@ -666,10 +666,10 @@ cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q)
 {
     // code adapted from https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
 
-    const double q0 = q[0];
-    const double q1 = q[1];
-    const double q2 = q[2];
-    const double q3 = q[3];
+    const double q0 = q[3];
+    const double q1 = q[0];
+    const double q2 = q[1];
+    const double q3 = q[2];
      
     cv::Mat rot_matrix(3, 3, CV_64F);
     rot_matrix.at<double>(0, 0) = 2 * (q0 * q0 + q1 * q1) - 1;
@@ -714,6 +714,7 @@ cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std
     cv::Mat A = cv::Mat::zeros(4, 4, CV_64F);
     for (cv::Mat& q: quaternions)
     {
+      // TODO check order of quaternion here!
       if (q.at<double>(0, 1) < 0)
       {
         // handle the antipodal configurations

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -536,8 +536,7 @@ cv::Mat handeyeBootstratpTranslationCalibration(
   }
 
   // if enough sucess (at least 3) then compute median value
-  if (nb_success > 3) 
-  {
+  if (nb_success > 3) {
     cv::Mat r_he = getAverageRotation(r1_he, r2_he, r3_he);
     cv::Mat t_he = cv::Mat::zeros(3, 1, CV_64F);
     t_he.at<double>(0) = median(t1_he);
@@ -626,84 +625,88 @@ void projectPointsWithDistortion(std::vector<cv::Point3f> object_pts,
   }
 }
 
-cv::Mat convertRotationMatrixToQuaternion(cv::Mat R)
-{
-  // code is adapted from https://gist.github.com/shubh-agrawal/76754b9bfb0f4143819dbd146d15d4c8
+cv::Mat convertRotationMatrixToQuaternion(cv::Mat R) {
+  // code is adapted from
+  // https://gist.github.com/shubh-agrawal/76754b9bfb0f4143819dbd146d15d4c8
 
   cv::Mat Q(1, 4, CV_64F); // x y z w
 
-  double trace = R.at<double>(0,0) + R.at<double>(1,1) + R.at<double>(2,2);
+  double trace = R.at<double>(0, 0) + R.at<double>(1, 1) + R.at<double>(2, 2);
 
-  if (trace > 0.0) 
-  {
-      double s = std::sqrt(trace + 1.0);
-      Q.at<double>(0, 3) = (s * 0.5);
-      s = 0.5 / s;
-      Q.at<double>(0, 0) = ((R.at<double>(2,1) - R.at<double>(1,2)) * s);
-      Q.at<double>(0, 1) = ((R.at<double>(0,2) - R.at<double>(2,0)) * s);
-      Q.at<double>(0, 2) = ((R.at<double>(1,0) - R.at<double>(0,1)) * s);
-  } 
-  
-  else 
-  {
-      int i = R.at<double>(0,0) < R.at<double>(1,1) ? (R.at<double>(1,1) < R.at<double>(2,2) ? 2 : 1) : (R.at<double>(0,0) < R.at<double>(2,2) ? 2 : 0); 
-      int j = (i + 1) % 3;  
-      int k = (i + 2) % 3;
+  if (trace > 0.0) {
+    double s = std::sqrt(trace + 1.0);
+    Q.at<double>(0, 3) = (s * 0.5);
+    s = 0.5 / s;
+    Q.at<double>(0, 0) = ((R.at<double>(2, 1) - R.at<double>(1, 2)) * s);
+    Q.at<double>(0, 1) = ((R.at<double>(0, 2) - R.at<double>(2, 0)) * s);
+    Q.at<double>(0, 2) = ((R.at<double>(1, 0) - R.at<double>(0, 1)) * s);
+  }
 
-      double s = std::sqrt(R.at<double>(i, i) - R.at<double>(j,j) - R.at<double>(k,k) + 1.0);
-      Q.at<double>(0, i) = s * 0.5;
-      s = 0.5 / s;
+  else {
+    int i = R.at<double>(0, 0) < R.at<double>(1, 1)
+                ? (R.at<double>(1, 1) < R.at<double>(2, 2) ? 2 : 1)
+                : (R.at<double>(0, 0) < R.at<double>(2, 2) ? 2 : 0);
+    int j = (i + 1) % 3;
+    int k = (i + 2) % 3;
 
-      Q.at<double>(0, 3) = (R.at<double>(k,j) - R.at<double>(j,k)) * s;
-      Q.at<double>(0, j) = (R.at<double>(j,i) + R.at<double>(i,j)) * s;
-      Q.at<double>(0, k) = (R.at<double>(k,i) + R.at<double>(i,k)) * s;
+    double s = std::sqrt(R.at<double>(i, i) - R.at<double>(j, j) -
+                         R.at<double>(k, k) + 1.0);
+    Q.at<double>(0, i) = s * 0.5;
+    s = 0.5 / s;
+
+    Q.at<double>(0, 3) = (R.at<double>(k, j) - R.at<double>(j, k)) * s;
+    Q.at<double>(0, j) = (R.at<double>(j, i) + R.at<double>(i, j)) * s;
+    Q.at<double>(0, k) = (R.at<double>(k, i) + R.at<double>(i, k)) * s;
   }
 
   return Q;
 }
 
-cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q)
-{
-    // code adapted from https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
+cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4> &q) {
+  // code adapted from
+  // https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
 
-    const double q0 = q[3];
-    const double q1 = q[0];
-    const double q2 = q[1];
-    const double q3 = q[2];
-     
-    cv::Mat rot_matrix(3, 3, CV_64F);
-    rot_matrix.at<double>(0, 0) = 2 * (q0 * q0 + q1 * q1) - 1;
-    rot_matrix.at<double>(0, 1) = 2 * (q1 * q2 - q0 * q3);
-    rot_matrix.at<double>(0, 2) = 2 * (q1 * q3 + q0 * q2);
-     
-    rot_matrix.at<double>(1, 0) = 2 * (q1 * q2 + q0 * q3);
-    rot_matrix.at<double>(1, 1) = 2 * (q0 * q0 + q2 * q2) - 1;
-    rot_matrix.at<double>(1, 2) = 2 * (q2 * q3 - q0 * q1);
-     
-    rot_matrix.at<double>(2, 0) = 2 * (q1 * q3 - q0 * q2);
-    rot_matrix.at<double>(2, 1) = 2 * (q2 * q3 + q0 * q1);
-    rot_matrix.at<double>(2, 2) = 2 * (q0 * q0 + q3 * q3) - 1;
-                            
-    return rot_matrix;
+  const double q0 = q[3];
+  const double q1 = q[0];
+  const double q2 = q[1];
+  const double q3 = q[2];
+
+  cv::Mat rot_matrix(3, 3, CV_64F);
+  rot_matrix.at<double>(0, 0) = 2 * (q0 * q0 + q1 * q1) - 1;
+  rot_matrix.at<double>(0, 1) = 2 * (q1 * q2 - q0 * q3);
+  rot_matrix.at<double>(0, 2) = 2 * (q1 * q3 + q0 * q2);
+
+  rot_matrix.at<double>(1, 0) = 2 * (q1 * q2 + q0 * q3);
+  rot_matrix.at<double>(1, 1) = 2 * (q0 * q0 + q2 * q2) - 1;
+  rot_matrix.at<double>(1, 2) = 2 * (q2 * q3 - q0 * q1);
+
+  rot_matrix.at<double>(2, 0) = 2 * (q1 * q3 - q0 * q2);
+  rot_matrix.at<double>(2, 1) = 2 * (q2 * q3 + q0 * q1);
+  rot_matrix.at<double>(2, 2) = 2 * (q0 * q0 + q3 * q3) - 1;
+
+  return rot_matrix;
 }
 
-cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging)
-{
+cv::Mat getAverageRotation(std::vector<double> &r1, std::vector<double> &r2,
+                           std::vector<double> &r3,
+                           const bool use_quaternion_averaging) {
   cv::Mat average_rotation = cv::Mat::zeros(3, 1, CV_64F);
-  if (use_quaternion_averaging)
-  {
-    // The Quaternion Averaging algorithm is described in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20070017872.pdf
+  if (use_quaternion_averaging) {
+    // The Quaternion Averaging algorithm is described in
+    // https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20070017872.pdf
     // implementaion references:
-    //  - https://gist.github.com/PeteBlackerThe3rd/f73e9d569e29f23e8bd828d7886636a0
-    //  - https://github.com/tolgabirdal/averaging_quaternions/blob/master/avg_quaternion_markley.m
+    //  -
+    //  https://gist.github.com/PeteBlackerThe3rd/f73e9d569e29f23e8bd828d7886636a0
+    //  -
+    //  https://github.com/tolgabirdal/averaging_quaternions/blob/master/avg_quaternion_markley.m
 
     assert(r1.size() == r2.size() && r2.size() == r3.size());
 
     std::vector<cv::Mat> quaternions;
     // convert rotation vector to quaternion through rotation matrix
-    for (unsigned int angle_idx = 0u; angle_idx < r1.size(); ++angle_idx)
-    {
-      std::array<double, 3> angles = { r1[angle_idx], r2[angle_idx], r3[angle_idx] };
+    for (unsigned int angle_idx = 0u; angle_idx < r1.size(); ++angle_idx) {
+      std::array<double, 3> angles = {r1[angle_idx], r2[angle_idx],
+                                      r3[angle_idx]};
       const cv::Mat rot_vec = cv::Mat(1, 3, CV_64F, angles.data());
       cv::Mat rot_matrix;
       cv::Rodrigues(rot_vec, rot_matrix);
@@ -712,11 +715,9 @@ cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std
     }
 
     cv::Mat A = cv::Mat::zeros(4, 4, CV_64F);
-    for (cv::Mat& q: quaternions)
-    {
+    for (cv::Mat &q : quaternions) {
       // TODO check order of quaternion here!
-      if (q.at<double>(0, 1) < 0)
-      {
+      if (q.at<double>(0, 1) < 0) {
         // handle the antipodal configurations
         q = -q;
       }
@@ -728,19 +729,26 @@ cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std
     cv::Mat U = svd.u;
     cv::Mat singularValues = svd.w;
 
-    // TODO: need to verify whether it's a row or a column vector; below treated as column vector
+    // TODO: need to verify whether it's a row or a column vector; below treated
+    // as column vector
     const unsigned int largestEigenValueIndex = 0u;
-    std::array<double, 4> average_quaternion = {svd.u.at<double>(0, largestEigenValueIndex), svd.u.at<double>(1, largestEigenValueIndex), 
-                                          svd.u.at<double>(2, largestEigenValueIndex), svd.u.at<double>(3, largestEigenValueIndex)};
-    
-    // std::array<double, 4> average_quaternion = {svd.u.at<double>(largestEigenValueIndex, 0), svd.u.at<double>(largestEigenValueIndex, 1), 
-    //                                             svd.u.at<double>(largestEigenValueIndex, 2), svd.u.at<double>(largestEigenValueIndex, 3)};
+    std::array<double, 4> average_quaternion = {
+        svd.u.at<double>(0, largestEigenValueIndex),
+        svd.u.at<double>(1, largestEigenValueIndex),
+        svd.u.at<double>(2, largestEigenValueIndex),
+        svd.u.at<double>(3, largestEigenValueIndex)};
+
+    // std::array<double, 4> average_quaternion =
+    // {svd.u.at<double>(largestEigenValueIndex, 0),
+    // svd.u.at<double>(largestEigenValueIndex, 1),
+    //                                             svd.u.at<double>(largestEigenValueIndex,
+    //                                             2),
+    //                                             svd.u.at<double>(largestEigenValueIndex,
+    //                                             3)};
 
     cv::Mat rot_matrix = convertQuaternionToRotationMatrix(average_quaternion);
     cv::Rodrigues(rot_matrix, average_rotation);
-  }
-  else
-  {
+  } else {
     average_rotation.at<double>(0) = median(r1);
     average_rotation.at<double>(1) = median(r2);
     average_rotation.at<double>(2) = median(r3);

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -716,8 +716,7 @@ cv::Mat getAverageRotation(std::vector<double> &r1, std::vector<double> &r2,
 
     cv::Mat A = cv::Mat::zeros(4, 4, CV_64F);
     for (cv::Mat &q : quaternions) {
-      // TODO check order of quaternion here!
-      if (q.at<double>(0, 1) < 0) {
+      if (q.at<double>(0, 3) < 0) {
         // handle the antipodal configurations
         q = -q;
       }
@@ -729,22 +728,12 @@ cv::Mat getAverageRotation(std::vector<double> &r1, std::vector<double> &r2,
     cv::Mat U = svd.u;
     cv::Mat singularValues = svd.w;
 
-    // TODO: need to verify whether it's a row or a column vector; below treated
-    // as column vector
     const unsigned int largestEigenValueIndex = 0u;
     std::array<double, 4> average_quaternion = {
         svd.u.at<double>(0, largestEigenValueIndex),
         svd.u.at<double>(1, largestEigenValueIndex),
         svd.u.at<double>(2, largestEigenValueIndex),
         svd.u.at<double>(3, largestEigenValueIndex)};
-
-    // std::array<double, 4> average_quaternion =
-    // {svd.u.at<double>(largestEigenValueIndex, 0),
-    // svd.u.at<double>(largestEigenValueIndex, 1),
-    //                                             svd.u.at<double>(largestEigenValueIndex,
-    //                                             2),
-    //                                             svd.u.at<double>(largestEigenValueIndex,
-    //                                             3)};
 
     cv::Mat rot_matrix = convertQuaternionToRotationMatrix(average_quaternion);
     cv::Rodrigues(rot_matrix, average_rotation);

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -536,12 +536,10 @@ cv::Mat handeyeBootstratpTranslationCalibration(
   }
 
   // if enough sucess (at least 3) then compute median value
-  if (nb_success > 3) {
-    cv::Mat r_he = cv::Mat::zeros(3, 1, CV_64F);
+  if (nb_success > 3) 
+  {
+    cv::Mat r_he = getAverageRotation(r1_he, r2_he, r3_he);
     cv::Mat t_he = cv::Mat::zeros(3, 1, CV_64F);
-    r_he.at<double>(0) = median(r1_he);
-    r_he.at<double>(1) = median(r2_he);
-    r_he.at<double>(2) = median(r3_he);
     t_he.at<double>(0) = median(t1_he);
     t_he.at<double>(1) = median(t2_he);
     t_he.at<double>(2) = median(t3_he);
@@ -626,4 +624,126 @@ void projectPointsWithDistortion(std::vector<cv::Point3f> object_pts,
     cv::fisheye::projectPoints(object_pts, repro_pts, rot, trans, camera_matrix,
                                distortion_vector, 0.0);
   }
+}
+
+cv::Mat convertRotationMatrixToQuaternion(cv::Mat R)
+{
+  // code is adapted from https://gist.github.com/shubh-agrawal/76754b9bfb0f4143819dbd146d15d4c8
+
+  cv::Mat Q(1, 4, CV_64F);;
+
+  double trace = R.at<double>(0,0) + R.at<double>(1,1) + R.at<double>(2,2);
+
+  if (trace > 0.0) 
+  {
+      double s = std::sqrt(trace + 1.0);
+      Q.at<double>(0, 3) = (s * 0.5);
+      s = 0.5 / s;
+      Q.at<double>(0, 0) = ((R.at<double>(2,1) - R.at<double>(1,2)) * s);
+      Q.at<double>(0, 1) = ((R.at<double>(0,2) - R.at<double>(2,0)) * s);
+      Q.at<double>(0, 2) = ((R.at<double>(1,0) - R.at<double>(0,1)) * s);
+  } 
+  
+  else 
+  {
+      int i = R.at<double>(0,0) < R.at<double>(1,1) ? (R.at<double>(1,1) < R.at<double>(2,2) ? 2 : 1) : (R.at<double>(0,0) < R.at<double>(2,2) ? 2 : 0); 
+      int j = (i + 1) % 3;  
+      int k = (i + 2) % 3;
+
+      double s = std::sqrt(R.at<double>(i, i) - R.at<double>(j,j) - R.at<double>(k,k) + 1.0);
+      Q.at<double>(0, i) = s * 0.5;
+      s = 0.5 / s;
+
+      Q.at<double>(0, 3) = (R.at<double>(k,j) - R.at<double>(j,k)) * s;
+      Q.at<double>(0, j) = (R.at<double>(j,i) + R.at<double>(i,j)) * s;
+      Q.at<double>(0, k) = (R.at<double>(k,i) + R.at<double>(i,k)) * s;
+  }
+
+  return Q;
+}
+
+cv::Mat convertQuaternionToRotationMatrix(const std::array<double, 4>& q)
+{
+    // code adapted from https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
+
+    const double q0 = q[0];
+    const double q1 = q[1];
+    const double q2 = q[2];
+    const double q3 = q[3];
+     
+    cv::Mat rot_matrix(3, 3, CV_64F);
+    rot_matrix.at<double>(0, 0) = 2 * (q0 * q0 + q1 * q1) - 1;
+    rot_matrix.at<double>(0, 1) = 2 * (q1 * q2 - q0 * q3);
+    rot_matrix.at<double>(0, 2) = 2 * (q1 * q3 + q0 * q2);
+     
+    rot_matrix.at<double>(1, 0) = 2 * (q1 * q2 + q0 * q3);
+    rot_matrix.at<double>(1, 1) = 2 * (q0 * q0 + q2 * q2) - 1;
+    rot_matrix.at<double>(1, 2) = 2 * (q2 * q3 - q0 * q1);
+     
+    rot_matrix.at<double>(2, 0) = 2 * (q1 * q3 - q0 * q2);
+    rot_matrix.at<double>(2, 1) = 2 * (q2 * q3 + q0 * q1);
+    rot_matrix.at<double>(2, 2) = 2 * (q0 * q0 + q3 * q3) - 1;
+                            
+    return rot_matrix;
+}
+
+cv::Mat getAverageRotation(std::vector<double>& r1, std::vector<double>& r2, std::vector<double>& r3, const bool use_quaternion_averaging)
+{
+  cv::Mat average_rotation = cv::Mat::zeros(3, 1, CV_64F);
+  if (use_quaternion_averaging)
+  {
+    // The Quaternion Averaging algorithm is described in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20070017872.pdf
+    // implementaion references:
+    //  - https://gist.github.com/PeteBlackerThe3rd/f73e9d569e29f23e8bd828d7886636a0
+    //  - https://github.com/tolgabirdal/averaging_quaternions/blob/master/avg_quaternion_markley.m
+
+    assert(r1.size() == r2.size() && r2.size() == r3.size());
+
+    std::vector<cv::Mat> quaternions;
+    // convert rotation vector to quaternion through rotation matrix
+    for (unsigned int angle_idx = 0u; angle_idx < r1.size(); ++angle_idx)
+    {
+      std::array<double, 3> angles = { r1[angle_idx], r2[angle_idx], r3[angle_idx] };
+      const cv::Mat rot_vec = cv::Mat(1, 3, CV_64F, angles.data());
+      cv::Mat rot_matrix;
+      cv::Rodrigues(rot_vec, rot_matrix);
+      const cv::Mat quaternion = convertRotationMatrixToQuaternion(rot_matrix);
+      quaternions.push_back(quaternion);
+    }
+
+    cv::Mat A = cv::Mat::zeros(4, 4, CV_64F);
+    for (cv::Mat& q: quaternions)
+    {
+      if (q.at<double>(0, 1) < 0)
+      {
+        // handle the antipodal configurations
+        q = -q;
+      }
+      A += q.t() * q;
+    }
+    A /= quaternions.size();
+
+    cv::SVD svd(A, cv::SVD::FULL_UV);
+    cv::Mat U = svd.u;
+    cv::Mat singularValues = svd.w;
+
+    // TODO: need to verify whether it's a row or a column vector; below treated as column vector
+    const unsigned int largestEigenValueIndex = 0u;
+    std::array<double, 4> average_quaternion = {svd.u.at<double>(0, largestEigenValueIndex), svd.u.at<double>(1, largestEigenValueIndex), 
+                                          svd.u.at<double>(2, largestEigenValueIndex), svd.u.at<double>(3, largestEigenValueIndex)};
+    
+    // std::array<double, 4> average_quaternion = {svd.u.at<double>(largestEigenValueIndex, 0), svd.u.at<double>(largestEigenValueIndex, 1), 
+    //                                             svd.u.at<double>(largestEigenValueIndex, 2), svd.u.at<double>(largestEigenValueIndex, 3)};
+
+    cv::Mat rot_matrix = convertQuaternionToRotationMatrix(average_quaternion);
+    cv::Rodrigues(rot_matrix, average_rotation);
+  }
+  else
+  {
+    average_rotation.at<double>(0) = median(r1);
+    average_rotation.at<double>(1) = median(r2);
+    average_rotation.at<double>(2) = median(r3);
+  }
+
+  return average_rotation;
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ cam_prefix: "Cam_"
 keypoints_path: "None"      # "path_to/detected_keypoints_data.yml" to save time on keypoint detection
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1     # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000     # Max number of iterations for the non linear refinement
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ The calibration toolbox automatically outputs four ```*.yml``` files. To illustr
 
 # Datasets
 The synthetic and real datasets acquired for this paper are freely available via the following links:
-- [Real Data](https://bosch.frameau.xyz/index.php/s/fqtFij4PNc9mp2a)
-- [Synthetic Data](https://bosch.frameau.xyz/index.php/s/pLc2T9bApbeLmSz)
+- [Real Data](https://drive.google.com/file/d/143jdSi5fxUGj1iEGbTIQPfSqcOyuW-MR/view?usp=sharing)
+- [Synthetic Data](https://drive.google.com/file/d/1CxaXUbO4E9WmaVrYy5aMeRLKmrFB_ARl/view?usp=sharing)
 
 
 # Contribution

--- a/configs/Blender_Images/calib_param_synth_Scenario1.yml
+++ b/configs/Blender_Images/calib_param_synth_Scenario1.yml
@@ -29,9 +29,10 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Blender_Images/Scenario_1/Images/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Blender_Images/Scenario_1/Results/detected_keypoints_data.yml"
+keypoints_path: "../data/Blender_Images/Scenario_1/Results/detected_keypoints_data.yml" # "None" #
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10       # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000    # Max number of iterations for the non linear refinement
 

--- a/configs/Blender_Images/calib_param_synth_Scenario2.yml
+++ b/configs/Blender_Images/calib_param_synth_Scenario2.yml
@@ -29,9 +29,10 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Blender_Images/Scenario_2/Images/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Blender_Images/Scenario_2/Results/detected_keypoints_data.yml" 
+keypoints_path: "../data/Blender_Images/Scenario_2/Results/detected_keypoints_data.yml" # "None" #
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10       # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000    # Max number of iterations for the non linear refinement
 

--- a/configs/Blender_Images/calib_param_synth_Scenario3.yml
+++ b/configs/Blender_Images/calib_param_synth_Scenario3.yml
@@ -30,9 +30,10 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Blender_Images/Scenario_3/Images/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Blender_Images/Scenario_3/Results/detected_keypoints_data.yml"  
+keypoints_path: "../data/Blender_Images/Scenario_3/Results/detected_keypoints_data.yml"  
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10       # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000    # Max number of iterations for the non linear refinement
 

--- a/configs/Blender_Images/calib_param_synth_Scenario4.yml
+++ b/configs/Blender_Images/calib_param_synth_Scenario4.yml
@@ -30,9 +30,10 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Blender_Images/Scenario_4/Images/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Blender_Images/Scenario_4/Results/detected_keypoints_data.yml" 
+keypoints_path: "../data/Blender_Images/Scenario_4/Results/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10       # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000    # Max number of iterations for the non linear refinement
 

--- a/configs/Blender_Images/calib_param_synth_Scenario5.yml
+++ b/configs/Blender_Images/calib_param_synth_Scenario5.yml
@@ -29,9 +29,10 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Blender_Images/Scenario_5/Images/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Blender_Images/Scenario_5/Results/detected_keypoints_data.yml"  
+keypoints_path: "../data/Blender_Images/Scenario_5/Results/detected_keypoints_data.yml"  
 
 ######################################## Optimization Parameters #############################################
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
 ransac_threshold: 10       # RANSAC threshold in pixel (keep it high just to remove strong outliers)
 number_iterations: 1000    # Max number of iterations for the non linear refinement
 

--- a/configs/Real_images/calib_param_Seq00_Stereo_vision.yml
+++ b/configs/Real_images/calib_param_Seq00_Stereo_vision.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq00_Stereo_vision/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq00_Stereo_vision/detected_keypoints_data.yml" 
+keypoints_path: "../data/Real_Images/Seq00_Stereo_vision/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/configs/Real_images/calib_param_Seq01_Non-overlapping.yml
+++ b/configs/Real_images/calib_param_Seq01_Non-overlapping.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq01_Non-overlapping/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq01_Non-overlapping/detected_keypoints_data.yml" 
+keypoints_path: "../data/Real_Images/Seq01_Non-overlapping/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/configs/Real_images/calib_param_Seq02_Overlapping_multicamera.yml
+++ b/configs/Real_images/calib_param_Seq02_Overlapping_multicamera.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq02_Overlapping_multicamera/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq02_Overlapping_multicamera/detected_keypoints_data.yml" 
+keypoints_path: "../data/Real_Images/Seq02_Overlapping_multicamera/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/configs/Real_images/calib_param_Seq03_hybrid.yml
+++ b/configs/Real_images/calib_param_Seq03_hybrid.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq03_hybrid/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq03_hybrid/detected_keypoints_data.yml" 
+keypoints_path: "../data/Real_Images/Seq03_hybrid/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/configs/Real_images/calib_param_Seq04_Converging_vision.yml
+++ b/configs/Real_images/calib_param_Seq04_Converging_vision.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq04_Converging_vision/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq04_Converging_vision/detected_keypoints_data.yml" 
+keypoints_path: "../data/Real_Images/Seq04_Converging_vision/detected_keypoints_data.yml" 
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/configs/Real_images/calib_param_Seq05_Non_overlapping_6Cam.yml
+++ b/configs/Real_images/calib_param_Seq05_Non_overlapping_6Cam.yml
@@ -31,11 +31,12 @@ fix_intrinsic: 0 #if 1 then the intrinsic parameters will not be estimated nor r
 ######################################## Images Parameters ###################################################
 root_path: "../data/Real_Images/Seq05_Non_overlapping_6Cam/" #"../../Images_Sim1Cam3Board/" # "../../Images_NonOver3/"  "../../Images_Cube/" "../../Images_Plan/" "../../Images_NonOver6Cam/"
 cam_prefix: "Cam_"
-keypoints_path: "None" #"../data/Real_Images/Seq05_Non_overlapping_6Cam/detected_keypoints_data.yml"
+keypoints_path: "../data/Real_Images/Seq05_Non_overlapping_6Cam/detected_keypoints_data.yml"
 
 ######################################## Optimization Parameters ###################################################
-ransac_threshold: 3 #RANSAC threshold in pixel (keep it high just to remove strong outliers)
-number_iterations: 1000 #Max number of iterations for the non linear refinement
+quaternion_averaging: 1    # use Quaternion Averaging or median for average rotation
+ransac_threshold: 3        # RANSAC threshold in pixel (keep it high just to remove strong outliers)
+number_iterations: 1000    # Max number of iterations for the non linear refinement
 
 ######################################## Hand-eye method #############################################
 he_approach: 0 #0: bootstrapped he technique, 1: traditional he

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package (Boost REQUIRED COMPONENTS unit_test_framework log_setup log filesystem REQUIRED)
 
 set(SOURCES
-    main.cpp test_graph.cpp test_calibration.cpp simple_unit_tests_example.cpp
+    main.cpp test_graph.cpp test_calibration.cpp test_geometrytools.cpp simple_unit_tests_example.cpp
 )
 
 add_executable(boost_tests_run ${SOURCES})

--- a/tests/test_geometrytools.cpp
+++ b/tests/test_geometrytools.cpp
@@ -4,91 +4,92 @@
 
 BOOST_AUTO_TEST_SUITE(CheckGeometryTools)
 
-
-double INTRINSICS_TOLERANCE = 1.0;  // in percentage
-
+double INTRINSICS_TOLERANCE = 1.0; // in percentage
 
 BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionConversion1) {
-  std::array<double, 9> rot_matrix_data = {1, 0, 0,
-                                           0, 1, 0,
-                                           0, 0, 1};
+  std::array<double, 9> rot_matrix_data = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   const cv::Mat rot_matrix = cv::Mat(3, 3, CV_64F, rot_matrix_data.data());
   const cv::Mat quaternion_pred = convertRotationMatrixToQuaternion(rot_matrix);
 
   std::array<double, 4> quaternion_gt_data = {0, 0, 0, 1};
-  const cv::Mat quaternion_gt = cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
+  const cv::Mat quaternion_gt =
+      cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
 
   BOOST_REQUIRE_EQUAL(quaternion_pred.size[0], quaternion_gt.size[0]);
   BOOST_REQUIRE_EQUAL(quaternion_pred.size[1], quaternion_gt.size[1]);
-  for (int i = 0; i < quaternion_pred.size[1]; ++i)
-  {
-    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i), quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
+  for (int i = 0; i < quaternion_pred.size[1]; ++i) {
+    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i),
+                      quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
   }
 }
 
 BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionConversion2) {
   std::array<double, 9> rot_matrix_data = {-0.9999, -0.1998, -0.3996,
-                                           0.1998, 0.6000, -0.8000,
-                                           0.3996, -0.8000, -0.5999};
+                                           0.1998,  0.6000,  -0.8000,
+                                           0.3996,  -0.8000, -0.5999};
   const cv::Mat rot_matrix = cv::Mat(3, 3, CV_64F, rot_matrix_data.data());
   const cv::Mat quaternion_pred = convertRotationMatrixToQuaternion(rot_matrix);
 
-  std::array<double, 4> quaternion_gt_data = {0, 0.8944, -0.4472, -0.2234}; // x y z w
-  const cv::Mat quaternion_gt = cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
+  std::array<double, 4> quaternion_gt_data = {0, 0.8944, -0.4472,
+                                              -0.2234}; // x y z w
+  const cv::Mat quaternion_gt =
+      cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
 
   BOOST_REQUIRE_EQUAL(quaternion_pred.size[0], quaternion_gt.size[0]);
   BOOST_REQUIRE_EQUAL(quaternion_pred.size[1], quaternion_gt.size[1]);
-  for (int i = 0; i < quaternion_pred.size[1]; ++i)
-  {
-    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i), quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
+  for (int i = 0; i < quaternion_pred.size[1]; ++i) {
+    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i),
+                      quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
   }
-
 }
 
 BOOST_AUTO_TEST_CASE(CheckQuaternionToRotationMatrixConversion) {
-  std::array<double, 4> quaternion_data = {0.2809946, 0.8377387, -0.4188693, -0.2092473}; // x y z w
+  std::array<double, 4> quaternion_data = {0.2809946, 0.8377387, -0.4188693,
+                                           -0.2092473}; // x y z w
   const cv::Mat quaternion = cv::Mat(1, 4, CV_64F, quaternion_data.data());
 
   cv::Mat rot_matrix_pred = convertQuaternionToRotationMatrix(quaternion);
 
-  std::array<double, 9> rot_matrix_gt_data = {-0.7545152,  0.2955056, -0.5859892,
-                                              0.6460947,  0.4911810, -0.5842113,
-                                              0.1151891, -0.8194008, -0.5615281};
-  const cv::Mat rot_matrix_gt = cv::Mat(3, 3, CV_64F, rot_matrix_gt_data.data());
+  std::array<double, 9> rot_matrix_gt_data = {
+      -0.7545152, 0.2955056, -0.5859892, 0.6460947, 0.4911810,
+      -0.5842113, 0.1151891, -0.8194008, -0.5615281};
+  const cv::Mat rot_matrix_gt =
+      cv::Mat(3, 3, CV_64F, rot_matrix_gt_data.data());
 
   BOOST_REQUIRE_EQUAL(rot_matrix_pred.size[0], rot_matrix_gt.size[0]);
   BOOST_REQUIRE_EQUAL(rot_matrix_pred.size[1], rot_matrix_gt.size[1]);
-  for (int i = 0; i < rot_matrix_pred.size[0]; ++i)
-  {
-    for (int j = 0; j < rot_matrix_pred.size[1]; ++j)
-    {
-      BOOST_CHECK_CLOSE(rot_matrix_pred.at<double>(i, j), rot_matrix_gt.at<double>(i, j), INTRINSICS_TOLERANCE);
+  for (int i = 0; i < rot_matrix_pred.size[0]; ++i) {
+    for (int j = 0; j < rot_matrix_pred.size[1]; ++j) {
+      BOOST_CHECK_CLOSE(rot_matrix_pred.at<double>(i, j),
+                        rot_matrix_gt.at<double>(i, j), INTRINSICS_TOLERANCE);
     }
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionAndBackConversion) {
-  for (int angle_x = -20; angle_x <= 20; ++angle_x)
-  {
-    for (int angle_y = -45; angle_y <= 90; ++angle_y)
-    {
-      for (int angle_z = -270; angle_z <= -180; ++angle_z)
-      {
-        std::array<double, 3> angles = { static_cast<double>(angle_x), static_cast<double>(angle_y), static_cast<double>(angle_z) };
+  for (int angle_x = -20; angle_x <= 20; ++angle_x) {
+    for (int angle_y = -45; angle_y <= 90; ++angle_y) {
+      for (int angle_z = -270; angle_z <= -180; ++angle_z) {
+        std::array<double, 3> angles = {static_cast<double>(angle_x),
+                                        static_cast<double>(angle_y),
+                                        static_cast<double>(angle_z)};
         const cv::Mat rot_vec = cv::Mat(1, 3, CV_64F, angles.data());
         cv::Mat rot_matrix_before;
         cv::Rodrigues(rot_vec, rot_matrix_before);
-        const cv::Mat quaternion = convertRotationMatrixToQuaternion(rot_matrix_before);
-        cv::Mat rot_matrix_after = convertQuaternionToRotationMatrix(quaternion);
+        const cv::Mat quaternion =
+            convertRotationMatrixToQuaternion(rot_matrix_before);
+        cv::Mat rot_matrix_after =
+            convertQuaternionToRotationMatrix(quaternion);
 
-        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[0], rot_matrix_before.size[0]);
-        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[1], rot_matrix_before.size[1]);
-        for (int i = 0; i < rot_matrix_after.size[0]; ++i)
-        {
-          for (int j = 0; j < rot_matrix_after.size[1]; ++j)
-          {
-            BOOST_CHECK_CLOSE(rot_matrix_after.at<double>(i, j), rot_matrix_before.at<double>(i, j), INTRINSICS_TOLERANCE);
+        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[0],
+                            rot_matrix_before.size[0]);
+        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[1],
+                            rot_matrix_before.size[1]);
+        for (int i = 0; i < rot_matrix_after.size[0]; ++i) {
+          for (int j = 0; j < rot_matrix_after.size[1]; ++j) {
+            BOOST_CHECK_CLOSE(rot_matrix_after.at<double>(i, j),
+                              rot_matrix_before.at<double>(i, j),
+                              INTRINSICS_TOLERANCE);
           }
         }
       }

--- a/tests/test_geometrytools.cpp
+++ b/tests/test_geometrytools.cpp
@@ -1,0 +1,99 @@
+#include <boost/test/unit_test.hpp>
+
+#include <geometrytools.hpp>
+
+BOOST_AUTO_TEST_SUITE(CheckGeometryTools)
+
+
+double INTRINSICS_TOLERANCE = 1.0;  // in percentage
+
+
+BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionConversion1) {
+  std::array<double, 9> rot_matrix_data = {1, 0, 0,
+                                           0, 1, 0,
+                                           0, 0, 1};
+  const cv::Mat rot_matrix = cv::Mat(3, 3, CV_64F, rot_matrix_data.data());
+  const cv::Mat quaternion_pred = convertRotationMatrixToQuaternion(rot_matrix);
+
+  std::array<double, 4> quaternion_gt_data = {0, 0, 0, 1};
+  const cv::Mat quaternion_gt = cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
+
+  BOOST_REQUIRE_EQUAL(quaternion_pred.size[0], quaternion_gt.size[0]);
+  BOOST_REQUIRE_EQUAL(quaternion_pred.size[1], quaternion_gt.size[1]);
+  for (int i = 0; i < quaternion_pred.size[1]; ++i)
+  {
+    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i), quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionConversion2) {
+  std::array<double, 9> rot_matrix_data = {-0.9999, -0.1998, -0.3996,
+                                           0.1998, 0.6000, -0.8000,
+                                           0.3996, -0.8000, -0.5999};
+  const cv::Mat rot_matrix = cv::Mat(3, 3, CV_64F, rot_matrix_data.data());
+  const cv::Mat quaternion_pred = convertRotationMatrixToQuaternion(rot_matrix);
+
+  std::array<double, 4> quaternion_gt_data = {0, 0.8944, -0.4472, -0.2234}; // x y z w
+  const cv::Mat quaternion_gt = cv::Mat(1, 4, CV_64F, quaternion_gt_data.data());
+
+  BOOST_REQUIRE_EQUAL(quaternion_pred.size[0], quaternion_gt.size[0]);
+  BOOST_REQUIRE_EQUAL(quaternion_pred.size[1], quaternion_gt.size[1]);
+  for (int i = 0; i < quaternion_pred.size[1]; ++i)
+  {
+    BOOST_CHECK_CLOSE(quaternion_pred.at<double>(i), quaternion_gt.at<double>(i), INTRINSICS_TOLERANCE);
+  }
+
+}
+
+BOOST_AUTO_TEST_CASE(CheckQuaternionToRotationMatrixConversion) {
+  std::array<double, 4> quaternion_data = {0.2809946, 0.8377387, -0.4188693, -0.2092473}; // x y z w
+  const cv::Mat quaternion = cv::Mat(1, 4, CV_64F, quaternion_data.data());
+
+  cv::Mat rot_matrix_pred = convertQuaternionToRotationMatrix(quaternion);
+
+  std::array<double, 9> rot_matrix_gt_data = {-0.7545152,  0.2955056, -0.5859892,
+                                              0.6460947,  0.4911810, -0.5842113,
+                                              0.1151891, -0.8194008, -0.5615281};
+  const cv::Mat rot_matrix_gt = cv::Mat(3, 3, CV_64F, rot_matrix_gt_data.data());
+
+  BOOST_REQUIRE_EQUAL(rot_matrix_pred.size[0], rot_matrix_gt.size[0]);
+  BOOST_REQUIRE_EQUAL(rot_matrix_pred.size[1], rot_matrix_gt.size[1]);
+  for (int i = 0; i < rot_matrix_pred.size[0]; ++i)
+  {
+    for (int j = 0; j < rot_matrix_pred.size[1]; ++j)
+    {
+      BOOST_CHECK_CLOSE(rot_matrix_pred.at<double>(i, j), rot_matrix_gt.at<double>(i, j), INTRINSICS_TOLERANCE);
+    }
+  }
+}
+
+
+BOOST_AUTO_TEST_CASE(CheckRotationMatrixToQuaternionAndBackConversion) {
+  for (int angle_x = -20; angle_x <= 20; ++angle_x)
+  {
+    for (int angle_y = -45; angle_y <= 90; ++angle_y)
+    {
+      for (int angle_z = -270; angle_z <= -180; ++angle_z)
+      {
+        std::array<double, 3> angles = { static_cast<double>(angle_x), static_cast<double>(angle_y), static_cast<double>(angle_z) };
+        const cv::Mat rot_vec = cv::Mat(1, 3, CV_64F, angles.data());
+        cv::Mat rot_matrix_before;
+        cv::Rodrigues(rot_vec, rot_matrix_before);
+        const cv::Mat quaternion = convertRotationMatrixToQuaternion(rot_matrix_before);
+        cv::Mat rot_matrix_after = convertQuaternionToRotationMatrix(quaternion);
+
+        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[0], rot_matrix_before.size[0]);
+        BOOST_REQUIRE_EQUAL(rot_matrix_after.size[1], rot_matrix_before.size[1]);
+        for (int i = 0; i < rot_matrix_after.size[0]; ++i)
+        {
+          for (int j = 0; j < rot_matrix_after.size[1]; ++j)
+          {
+            BOOST_CHECK_CLOSE(rot_matrix_after.at<double>(i, j), rot_matrix_before.at<double>(i, j), INTRINSICS_TOLERANCE);
+          }
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Improved rotation vector averaging using the Quaternion Averaging method described in the paper https://www.acsu.buffalo.edu/~johnc/ave_quat07.pdf

Mean projection error per sequence:

| Real Sequences | Naive Averaging | Quaternion Averaging |
|--------|:--------:|:--------:|
| Seq00_Stereo_vision | 0.372208 | 0.369823 |
| Seq01_Non-overlapping | 0.19613 | 0.195987 |
| Seq02_Overlapping_multicamera | 0.283885 | 0.283887 |
| Seq03_hybrid | 0.16435 | 0.164234 |
| Seq04_Converging_vision | 0.278782 | 0.278747 |
| Seq05_Non_overlapping_6Cam | 0.202215 | 0.202148 |  

| Blender Sequences | Naive Averaging | Quaternion Averaging |
|--------|:--------:|:--------:|
| Scenario1 | 0.021487 | 0.021487 |
| Scenario2 | 0.023335 | 0.023335 |
| Scenario3 | 0.0146587 | 0.0146588 |
| Scenario4 | 0.0176594 | 0.0176595 |
| Scenario5 | 0.104494 | 0.104494 | 