### PR TITLE
Improving CI pipeline with more steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           lfs: 'true'
 
       - name: Unzip MC-Calib-data
-        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data/Blender_Images
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
         
       - name: Run tests
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,47 +13,47 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  clang-format-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
-      - name: Run clang-format-lint
-        uses: DoozyX/clang-format-lint-action@v0.11
-        with:
-          source: '.'
-          exclude: './third_party ./external .git'
-          extensions: 'h,cpp'
-          clangFormatVersion: 11
+  # clang-format-lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
+  #     - name: Run clang-format-lint
+  #       uses: DoozyX/clang-format-lint-action@v0.11
+  #       with:
+  #         source: '.'
+  #         exclude: './third_party ./external .git'
+  #         extensions: 'h,cpp'
+  #         clangFormatVersion: 11
   
-  cppcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run cppcheck
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-dev:latest
-          options: -v ${{ github.workspace }}:/home/MC-Calib
-          run: |
-            cppcheck MC-Calib/McCalib/include
-            cppcheck MC-Calib/McCalib/src
+  # cppcheck:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Run cppcheck
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: bailool/mc-calib-dev:latest
+  #         options: -v ${{ github.workspace }}:/home/MC-Calib
+  #         run: |
+  #           cppcheck MC-Calib/McCalib/include
+  #           cppcheck MC-Calib/McCalib/src
 
-  clang-tidy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run clang-tidy
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-dev:latest
-          options: -v ${{ github.workspace }}:/home/MC-Calib
-          run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
-            run-clang-tidy
+  # clang-tidy:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Run clang-tidy
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: bailool/mc-calib-dev:latest
+  #         options: -v ${{ github.workspace }}:/home/MC-Calib
+  #         run: |
+  #           mkdir MC-Calib/build && cd MC-Calib/build
+  #           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
+  #           run-clang-tidy
 
   unit-tests-with-sanitizers:
     runs-on: ubuntu-latest
@@ -65,13 +65,16 @@ jobs:
         with:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
-      - name: Run tests
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-dev:latest
-          options: -v ${{ github.workspace }}:/home/MC-Calib
-          run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-            make -j8
-            ./tests/boost_tests_run
+          run: | 
+            ls
+            ls ${{ github.workspace }}/data
+      # - name: Run tests
+      #   uses: addnab/docker-run-action@v3
+      #   with:
+      #     image: bailool/mc-calib-dev:latest
+      #     options: -v ${{ github.workspace }}:/home/MC-Calib
+      #     run: |
+      #       mkdir MC-Calib/build && cd MC-Calib/build
+      #       cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+      #       make -j8
+      #       ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,9 +77,7 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
-            ls /home/MC-Calib/data
-            ls /home/MC-Calib/data/Blender_Images
-            # mkdir MC-Calib/build && cd MC-Calib/build
-            # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-            # make -j8
-            # ./tests/boost_tests_run
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -j8
+            ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,9 @@ jobs:
         with:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
-          run: | 
-            ls
-            ls ${{ github.workspace }}/data
+      - name: Unzip MC-Calib-data
+        run: ls ${{ github.workspace }}/data
+            
       # - name: Run tests
       #   uses: addnab/docker-run-action@v3
       #   with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
+            cppcheck MC-Calib/McCalib/include
             cppcheck MC-Calib/McCalib/src
 
   clang-tidy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,34 @@ jobs:
   #           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
   #           run-clang-tidy
 
-  unit-tests-with-sanitizers:
+  # unit-tests-with-sanitizers:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+
+  #     - name: Checkout MC-Calib-data
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: BAILOOL/MC-Calib-data
+  #         path: ${{ github.workspace }}/data
+  #         lfs: 'true'
+
+  #     - name: Unzip MC-Calib-data
+  #       run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+        
+  #     - name: Run tests
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: bailool/mc-calib-dev:latest
+  #         options: -v ${{ github.workspace }}:/home/MC-Calib
+  #         run: |
+  #           mkdir MC-Calib/build && cd MC-Calib/build
+  #           cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+  #           make -j4
+  #           ./tests/boost_tests_run
+
+  unit-tests-with-valgrind:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -83,6 +110,17 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
             make -j4
-            ./tests/boost_tests_run
+            valgrind --leak-check=full \
+              --leak-check=full \
+              --track-origins=yes \
+              --show-reachable=yes \
+              --error-limit=no \
+              --gen-suppressions=all \
+              --verbose \
+              --log-file=valgrind-out.txt \
+              --suppressions=../tests/valgrind_suppress/opencv_valgrind.supp \
+              --suppressions=../tests/valgrind_suppress/opencv_valgrind_3rdparty.supp \
+              --suppressions=../tests/valgrind_suppress/boost_valgrind.supp \
+              ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,22 +60,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
         with:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
           lfs: 'true'
+
       - name: Unzip MC-Calib-data
-        run: tar xzf ${{ github.workspace }}/data/Blender_Images.tar.gz
-            
-      # - name: Run tests
-      #   uses: addnab/docker-run-action@v3
-      #   with:
-      #     image: bailool/mc-calib-dev:latest
-      #     options: -v ${{ github.workspace }}:/home/MC-Calib
-      #     run: |
-      #       mkdir MC-Calib/build && cd MC-Calib/build
-      #       cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-      #       make -j8
-      #       ./tests/boost_tests_run
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz
+        
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -j8
+            ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,9 @@ jobs:
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
             run-clang-tidy
 
-
+  
   unit-tests-with-sanitizers:
+    if: ${{ false }}  # TODO: disable for now until understand how to suppress leaks from external libraries like OpenCV
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -139,3 +140,35 @@ jobs:
               --suppressions=../tests/valgrind_suppress/opencv_valgrind_3rdparty.supp \
               --suppressions=../tests/valgrind_suppress/boost_valgrind.supp \
               ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+
+
+  unit-tests-in-release-mode:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
+          lfs: 'true'
+
+      - name: Unzip MC-Calib-data
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+        
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,6 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib"
           run: |
+            ls
+            ls /home/MC-Calib/src
             cppcheck /home/MC-Calib/src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,9 @@ jobs:
         with:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
+          lfs: 'true'
       - name: Unzip MC-Calib-data
-        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz
+        run: tar xzf ${{ github.workspace }}/data/Blender_Images.tar.gz
             
       # - name: Run tests
       #   uses: addnab/docker-run-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,8 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-            make -j8
-            ./tests/boost_tests_run
+            ls /home/MC-Calib/data
+            # mkdir MC-Calib/build && cd MC-Calib/build
+            # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            # make -j8
+            # ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
         with:
-          repository: https://github.com/BAILOOL/MC-Calib-data
+          repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
       - name: Run tests
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,74 +18,77 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # clang-format-lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
-  #     - name: Run clang-format-lint
-  #       uses: DoozyX/clang-format-lint-action@v0.11
-  #       with:
-  #         source: '.'
-  #         exclude: './third_party ./external .git'
-  #         extensions: 'h,cpp'
-  #         clangFormatVersion: 11
+  clang-format-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
+
+      - name: Run clang-format-lint
+        uses: DoozyX/clang-format-lint-action@v0.11
+        with:
+          source: '.'
+          exclude: './third_party ./external .git'
+          extensions: 'h,cpp'
+          clangFormatVersion: 11
   
-  # cppcheck:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Run cppcheck
-  #       uses: addnab/docker-run-action@v3
-  #       with:
-  #         image: bailool/mc-calib-dev:latest
-  #         options: -v ${{ github.workspace }}:/home/MC-Calib
-  #         run: |
-  #           cppcheck MC-Calib/McCalib/include
-  #           cppcheck MC-Calib/McCalib/src
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  # clang-tidy:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Run clang-tidy
-  #       uses: addnab/docker-run-action@v3
-  #       with:
-  #         image: bailool/mc-calib-dev:latest
-  #         options: -v ${{ github.workspace }}:/home/MC-Calib
-  #         run: |
-  #           mkdir MC-Calib/build && cd MC-Calib/build
-  #           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
-  #           run-clang-tidy
+      - name: Run cppcheck
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            cppcheck MC-Calib/McCalib/include
+            cppcheck MC-Calib/McCalib/src
 
-  # unit-tests-with-sanitizers:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Checkout MC-Calib-data
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: BAILOOL/MC-Calib-data
-  #         path: ${{ github.workspace }}/data
-  #         lfs: 'true'
+      - name: Run clang-tidy
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
+            run-clang-tidy
 
-  #     - name: Unzip MC-Calib-data
-  #       run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+  unit-tests-with-sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
+          lfs: 'true'
+
+      - name: Unzip MC-Calib-data
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
         
-  #     - name: Run tests
-  #       uses: addnab/docker-run-action@v3
-  #       with:
-  #         image: bailool/mc-calib-dev:latest
-  #         options: -v ${{ github.workspace }}:/home/MC-Calib
-  #         run: |
-  #           mkdir MC-Calib/build && cd MC-Calib/build
-  #           cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-  #           make -j4
-  #           ./tests/boost_tests_run
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -j4
+            ./tests/boost_tests_run
 
   unit-tests-with-valgrind:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,19 @@ jobs:
             mkdir MC-Calib/build && cd MC-Calib/build
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
             run-clang-tidy
+
+  unit-tests-with-sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -j8
+            ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           lfs: 'true'
 
       - name: Unzip MC-Calib-data
-        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data/Blender_Images
         
       - name: Run tests
         uses: addnab/docker-run-action@v3
@@ -78,6 +78,7 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             ls /home/MC-Calib/data
+            ls /home/MC-Calib/data/Blender_Images
             # mkdir MC-Calib/build && cd MC-Calib/build
             # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
             # make -j8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,12 @@ jobs:
           exclude: './third_party ./external .git'
           extensions: 'h,cpp'
           clangFormatVersion: 11
+  
   cppcheck:
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/checkout@v2
-       - uses: addnab/docker-run-action@v3
+      - uses: actions/checkout@v2
+      - uses: addnab/docker-run-action@v3
         with:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib"
           run: |
+            pwd
             ls
             ls MC-Calib
-            cppcheck /home/MC-Calib/src
+            cd MC-Calib
+            cppcheck MC-Calib/src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: https://github.com/BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,18 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             cppcheck MC-Calib/McCalib/src
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run clang-tidy
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
+            run-clang-tidy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the action will run. 
@@ -15,12 +13,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  clang-format-lint:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v2
     - uses: DoozyX/clang-format-lint-action@v0.11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,6 @@ jobs:
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
             # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-            make -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
             make -j8
             ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           extensions: 'h,cpp'
           clangFormatVersion: 11
   
+
   cppcheck:
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +47,7 @@ jobs:
           run: |
             cppcheck MC-Calib/McCalib/include
             cppcheck MC-Calib/McCalib/src
+
 
   clang-tidy:
     runs-on: ubuntu-latest
@@ -63,8 +65,13 @@ jobs:
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
             run-clang-tidy
 
+
   unit-tests-with-sanitizers:
     runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -90,8 +97,13 @@ jobs:
             make -j4
             ./tests/boost_tests_run
 
+
   unit-tests-with-valgrind:
     runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,10 @@ jobs:
   clang-format-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.11
+      - name: Checkout
+        uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
+      - name: Run clang-format-lint
+        uses: DoozyX/clang-format-lint-action@v0.11
         with:
           source: '.'
           exclude: './third_party ./external .git'
@@ -27,8 +29,10 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: addnab/docker-run-action@v3
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run cppcheck
+        uses: addnab/docker-run-action@v3
         with:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
       - name: Unzip MC-Calib-data
-        run: ls ${{ github.workspace }}/data
+        run: tar xzf ${{ github.workspace }}/data/Blender_Images.tar.gz
             
       # - name: Run tests
       #   uses: addnab/docker-run-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,6 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
-            # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
-            make -j8
+            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -j4
             ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            # cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON ..
+            make -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
             make -j8
             ./tests/boost_tests_run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: bailool/mc-calib-dev:latest
-          options: -v ${{ github.workspace }}:/home/MC-Calib"
+          options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             pwd
             ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,5 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib"
           run: |
             ls
-            ls /home/MC-Calib/src
+            ls MC-Calib
             cppcheck /home/MC-Calib/src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,4 @@ jobs:
           image: bailool/mc-calib-dev:latest
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
-            pwd
-            ls
-            ls MC-Calib
-            cd MC-Calib
-            cppcheck MC-Calib/src
+            cppcheck MC-Calib/McCalib/src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           repository: BAILOOL/MC-Calib-data
           path: ${{ github.workspace }}/data
       - name: Unzip MC-Calib-data
-        run: tar xzf ${{ github.workspace }}/data/Blender_Images.tar.gz
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz
             
       # - name: Run tests
       #   uses: addnab/docker-run-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,20 @@ jobs:
   clang-format-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
-      with:
-        source: '.'
-        exclude: './third_party ./external .git'
-        extensions: 'h,cpp'
-        clangFormatVersion: 11
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.11
+        with:
+          source: '.'
+          exclude: './third_party ./external .git'
+          extensions: 'h,cpp'
+          clangFormatVersion: 11
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+       - uses: actions/checkout@v2
+       - uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-dev:latest
+          options: -v ${{ github.workspace }}:/home/MC-Calib"
+          run: |
+            cppcheck /home/MC-Calib/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
 if(USE_SANITIZERS)
     # sanitizers https://www.jetbrains.com/help/clion/google-sanitizers.html#Configuration
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,leak")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
 endif()
 
 include_directories(

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -253,7 +253,7 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
     cv::Mat image = cv::imread(fn[0]);
     if (image.empty())
     {
-        LOG_ERROR << "Could not read the image :: " << fn[0]);
+        LOG_ERROR << "Could not read the image :: " << fn[0];
         assert((!image.empty()) && "Calibration cannot be done");
     }
     cams_[cam_idx]->im_cols_ = image.cols;

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -290,7 +290,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
   // Greyscale image for subpixel refinement
   cv::Mat graymat;
   cv::cvtColor(image, graymat, cv::COLOR_BGR2GRAY);
-  
+
   // Datastructure to save the checkerboard corners
   // key == board id, value == markersIDs on MARKERS markerIds
   std::map<int, std::vector<int>> marker_idx;

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -277,12 +277,12 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
 void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int cam_idx,
                                                 const int frame_idx) {
-  LOG_INFO << "Got here1 "
+  LOG_INFO << "Got here1 ";
   cv::Mat image = cv::imread(frame_path);
   // Greyscale image for subpixel refinement
   cv::Mat graymat;
   cv::cvtColor(image, graymat, cv::COLOR_BGR2GRAY);
-  LOG_INFO << "Got here2 "
+  LOG_INFO << "Got here2 ";
   // Datastructure to save the checkerboard corners
 
   // key == board id, value == markersIDs on MARKERS markerIds
@@ -297,17 +297,17 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
   charuco_params_->adaptiveThreshConstant = 1;
 
   for (std::size_t i = 0; i < nb_board_; i++) {
-    LOG_INFO << "Got here3 "
+    LOG_INFO << "Got here3 ";
     cv::aruco::detectMarkers(image, boards_3d_[i]->charuco_board_->dictionary,
                              marker_corners[i], marker_idx[i], charuco_params_);
 
-    LOG_INFO << "Got here4 "
+    LOG_INFO << "Got here4 ";
     if (marker_corners[i].size() > 0) {
       cv::aruco::interpolateCornersCharuco(marker_corners[i], marker_idx[i],
                                            image, boards_3d_[i]->charuco_board_,
                                            charuco_corners[i], charuco_idx[i]);
     }
-    LOG_INFO << "Got here5 "
+    LOG_INFO << "Got here5 ";
 
     if (charuco_corners[i].size() >
         static_cast<std::size_t>(

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -282,7 +282,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
   if(image.empty())
   {
       std::cout << "Could not read the image: " << frame_path << std::endl;
-      return 1;
+      return;
   }
 
   LOG_INFO << "Got here1-2 ";

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -277,21 +277,18 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
 void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int cam_idx,
                                                 const int frame_idx) {
-  LOG_INFO << "Got here1 ";
   cv::Mat image = cv::imread(frame_path);
   if(image.empty())
   {
-      std::cout << "Could not read the image: " << frame_path << std::endl;
+      LOG_ERROR << "Could not read the image :: " << frame_path;
       return;
   }
 
-  LOG_INFO << "Got here1-2 ";
   // Greyscale image for subpixel refinement
   cv::Mat graymat;
   cv::cvtColor(image, graymat, cv::COLOR_BGR2GRAY);
-  LOG_INFO << "Got here2 ";
+  
   // Datastructure to save the checkerboard corners
-
   // key == board id, value == markersIDs on MARKERS markerIds
   std::map<int, std::vector<int>> marker_idx;
   // key == board id, value == 2d points visualized on MARKERS
@@ -304,17 +301,14 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
   charuco_params_->adaptiveThreshConstant = 1;
 
   for (std::size_t i = 0; i < nb_board_; i++) {
-    LOG_INFO << "Got here3 ";
     cv::aruco::detectMarkers(image, boards_3d_[i]->charuco_board_->dictionary,
                              marker_corners[i], marker_idx[i], charuco_params_);
 
-    LOG_INFO << "Got here4 ";
     if (marker_corners[i].size() > 0) {
       cv::aruco::interpolateCornersCharuco(marker_corners[i], marker_idx[i],
                                            image, boards_3d_[i]->charuco_board_,
                                            charuco_corners[i], charuco_idx[i]);
     }
-    LOG_INFO << "Got here5 ";
 
     if (charuco_corners[i].size() >
         static_cast<std::size_t>(

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -251,6 +251,11 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
   std::size_t num_frames = fn.size();
   if (num_frames > 0u) {
     cv::Mat image = cv::imread(fn[0]);
+    if (image.empty())
+    {
+        LOG_ERROR << "Could not read the image :: " << frame_path;
+        assert((!image.empty()) && "Calibration cannot be done");
+    }
     cams_[cam_idx]->im_cols_ = image.cols;
     cams_[cam_idx]->im_rows_ = image.rows;
   }
@@ -278,7 +283,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int cam_idx,
                                                 const int frame_idx) {
   cv::Mat image = cv::imread(frame_path);
-  if(image.empty())
+  if (image.empty())
   {
       LOG_ERROR << "Could not read the image :: " << frame_path;
       return;

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -277,11 +277,12 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
 void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int cam_idx,
                                                 const int frame_idx) {
+  LOG_INFO << "Got here1 "
   cv::Mat image = cv::imread(frame_path);
   // Greyscale image for subpixel refinement
   cv::Mat graymat;
   cv::cvtColor(image, graymat, cv::COLOR_BGR2GRAY);
-
+  LOG_INFO << "Got here2 "
   // Datastructure to save the checkerboard corners
 
   // key == board id, value == markersIDs on MARKERS markerIds
@@ -296,14 +297,17 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
   charuco_params_->adaptiveThreshConstant = 1;
 
   for (std::size_t i = 0; i < nb_board_; i++) {
+    LOG_INFO << "Got here3 "
     cv::aruco::detectMarkers(image, boards_3d_[i]->charuco_board_->dictionary,
                              marker_corners[i], marker_idx[i], charuco_params_);
 
+    LOG_INFO << "Got here4 "
     if (marker_corners[i].size() > 0) {
       cv::aruco::interpolateCornersCharuco(marker_corners[i], marker_idx[i],
                                            image, boards_3d_[i]->charuco_board_,
                                            charuco_corners[i], charuco_idx[i]);
     }
+    LOG_INFO << "Got here5 "
 
     if (charuco_corners[i].size() >
         static_cast<std::size_t>(

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -279,6 +279,12 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int frame_idx) {
   LOG_INFO << "Got here1 ";
   cv::Mat image = cv::imread(frame_path);
+  if(image.empty())
+  {
+      std::cout << "Could not read the image: " << frame_path << std::endl;
+      return 1;
+  }
+
   LOG_INFO << "Got here1-2 ";
   // Greyscale image for subpixel refinement
   cv::Mat graymat;

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -251,10 +251,9 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
   std::size_t num_frames = fn.size();
   if (num_frames > 0u) {
     cv::Mat image = cv::imread(fn[0]);
-    if (image.empty())
-    {
-        LOG_ERROR << "Could not read the image :: " << fn[0];
-        assert((!image.empty()) && "Calibration cannot be done");
+    if (image.empty()) {
+      LOG_ERROR << "Could not read the image :: " << fn[0];
+      assert((!image.empty()) && "Calibration cannot be done");
     }
     cams_[cam_idx]->im_cols_ = image.cols;
     cams_[cam_idx]->im_rows_ = image.rows;
@@ -283,10 +282,9 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int cam_idx,
                                                 const int frame_idx) {
   cv::Mat image = cv::imread(frame_path);
-  if (image.empty())
-  {
-      LOG_ERROR << "Could not read the image :: " << frame_path;
-      return;
+  if (image.empty()) {
+    LOG_ERROR << "Could not read the image :: " << frame_path;
+    return;
   }
 
   // Greyscale image for subpixel refinement

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -279,6 +279,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string frame_path,
                                                 const int frame_idx) {
   LOG_INFO << "Got here1 ";
   cv::Mat image = cv::imread(frame_path);
+  LOG_INFO << "Got here1-2 ";
   // Greyscale image for subpixel refinement
   cv::Mat graymat;
   cv::cvtColor(image, graymat, cv::COLOR_BGR2GRAY);

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -253,7 +253,7 @@ void Calibration::detectBoardsWithCamera(const std::vector<cv::String> &fn,
     cv::Mat image = cv::imread(fn[0]);
     if (image.empty())
     {
-        LOG_ERROR << "Could not read the image :: " << frame_path;
+        LOG_ERROR << "Could not read the image :: " << fn[0]);
         assert((!image.empty()) && "Calibration cannot be done");
     }
     cams_[cam_idx]->im_cols_ = image.cols;


### PR DESCRIPTION
Improving CI/CD pipeline:

- [x] cppcheck check build step
- [x] run-clang-tidy check build step
- [x] ASanitizer test
- [x] valgrind test
- [x] Run all unit tests in mc-calib-prod image in Release mode