### PR TITLE
Add support for OpenCV > v4.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,10 +166,32 @@ jobs:
       - name: Unzip MC-Calib-data
         run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
         
-      - name: Run tests
+      - name: Run tests with OpenCV==4.2.0
         uses: addnab/docker-run-action@v3
         with:
           image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
+
+      - name: Run tests with OpenCV==4.5.5
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:opencv455
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
+
+      - name: Run tests with OpenCV==4.10.0
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:opencv410
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
               ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
 
 
-  unit-tests-in-release-mode:
+  unit-tests-in-release-mode-opencv420:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -166,32 +166,10 @@ jobs:
       - name: Unzip MC-Calib-data
         run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
         
-      - name: Run tests with OpenCV==4.2.0
+      - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
           image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
-          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
-          run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Release ..
-            make -j4
-            ./tests/boost_tests_run
-
-      - name: Run tests with OpenCV==4.5.5
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-prod:opencv455
-          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
-          run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Release ..
-            make -j4
-            ./tests/boost_tests_run
-
-      - name: Run tests with OpenCV==4.10.0
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-prod:opencv410
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -230,6 +208,78 @@ jobs:
           name: results_blender_sequences
           path: ${{ github.workspace }}/data/Blender_Images/Results_Blender_Sequences
 
+  unit-tests-in-release-mode-opencv455:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
+          lfs: 'true'
+
+      - name: Unzip MC-Calib-data
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:opencv455
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
+
+  unit-tests-in-release-mode-opencv410:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
+          lfs: 'true'
+
+      - name: Unzip MC-Calib-data
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:opencv455
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
+
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bailool/mc-calib-prod:opencv410
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
 
   code-coverage-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,34 @@ jobs:
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
             run-clang-tidy
   
+  
+  test-charuco-boards-generation:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run charuco boards generation app
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./apps/create_charuco_boards/generate_charuco ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+
+      - name: Archive results artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: results_blender_sequences
+          path: ${{ github.workspace }}/build/charuco_boards
+
 
   unit-tests-with-sanitizers:
     if: ${{ false }}  # TODO: disable for now until understand how to suppress leaks from external libraries like OpenCV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
 
 env:
-  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv410
-  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv410
+  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv4100
+  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv4100
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
               ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
 
 
-  unit-tests-in-release-mode-opencv410:
+  unit-tests-in-release-mode-opencv4100:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -323,7 +323,7 @@ jobs:
   python-utils-linters:
     runs-on: ubuntu-latest
     needs:
-      - unit-tests-in-release-mode-opencv420
+      - unit-tests-in-release-mode-opencv4100
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -343,7 +343,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - python-utils-linters
-      - unit-tests-in-release-mode-opencv420
+      - unit-tests-in-release-mode-opencv4100
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
 
 env:
-  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv420
-  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv420
+  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv410
+  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv410
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -146,7 +146,7 @@ jobs:
               ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
 
 
-  unit-tests-in-release-mode-opencv420:
+  unit-tests-in-release-mode-opencv410:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -239,7 +239,7 @@ jobs:
             make -j4
             ./tests/boost_tests_run
 
-  unit-tests-in-release-mode-opencv410:
+  unit-tests-in-release-mode-opencv420:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -262,18 +262,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: bailool/mc-calib-prod:opencv410
-          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
-          run: |
-            mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Release ..
-            make -j4
-            ./tests/boost_tests_run
-
-      - name: Run tests
-        uses: addnab/docker-run-action@v3
-        with:
-          image: bailool/mc-calib-prod:opencv410
+          image: bailool/mc-calib-prod:opencv420
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: bailool/mc-calib-prod:opencv455
+          image: bailool/mc-calib-prod:opencv410
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ..
             run-clang-tidy
   
-  
+
   test-charuco-boards-generation:
     runs-on: ubuntu-latest
     needs:
@@ -94,7 +94,7 @@ jobs:
       - name: Archive results artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: results_blender_sequences
+          name: charuco_boards
           path: ${{ github.workspace }}/build/charuco_boards
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
   python-utils-linters:
     runs-on: ubuntu-latest
     needs:
-      - unit-tests-in-release-mode
+      - unit-tests-in-release-mode-opencv420
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -354,7 +354,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - python-utils-linters
-      - unit-tests-in-release-mode
+      - unit-tests-in-release-mode-opencv420
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ if(ENABLE_COVERAGE)
   # add coverage target
   add_custom_target(coverage
     # gather data
-    COMMAND ${LCOV} --directory . --capture --output-file coverage.info --exclude '/usr/*' --ignore-errors mismatch
+    COMMAND ${LCOV} --directory . --capture --output-file coverage.info --exclude '/usr/*' 
+      --ignore-errors mismatch,negative
     # generate report
     COMMAND ${GENHTML} --demangle-cpp -o coverage coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif (DOXYGEN_FOUND)
 
 
 ##########################################################################
-add_subdirectory(apps/create_charuco_boards)
 add_subdirectory(McCalib)
+add_subdirectory(apps/create_charuco_boards)
 add_subdirectory(apps/calibrate)
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(ENABLE_COVERAGE)
   # add coverage target
   add_custom_target(coverage
     # gather data
-    COMMAND ${LCOV} --directory . --capture --output-file coverage.info --exclude '/usr/*'
+    COMMAND ${LCOV} --directory . --capture --output-file coverage.info --exclude '/usr/*' --ignore-errors mismatch
     # generate report
     COMMAND ${GENHTML} --demangle-cpp -o coverage coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN git clone --branch 2.2.0 --single-branch https://github.com/ceres-solver/cer
 
 # Install python requirements for python_utils scripts
 RUN --mount=type=bind,source=python_utils/requirements_prod.txt,target=/tmp/requirements.txt \
-    python -m pip install --requirement /tmp/requirements.txt --break-system-packages && \
+	apt update && apt install -y libgl1 libglib2.0-0 && \    
+	python -m pip install --requirement /tmp/requirements.txt --break-system-packages && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM prod as dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as prod
+FROM ubuntu:24.04 as prod
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install -y --no-install-recommends apt-utils && \
@@ -15,14 +15,14 @@ WORKDIR /home
 #------------------------------	#
 #     INSTALL OPENCV 4		    #
 #------------------------------	#
-RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.2.0.zip && \
-	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/4.2.0.zip && \
+RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.10.0.zip && \
+	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/4.10.0.zip && \
 	unzip opencv.zip && unzip opencv_contrib.zip && \
 	mkdir -p build && cd build && \
-	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-4.2.0/modules ../opencv-4.2.0 && \
+	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-4.10.0/modules ../opencv-4.10.0 && \
 	cmake --build . --target install -- -j4 && \
 	cd /home && rm opencv.zip && rm opencv_contrib.zip && \ 
-	rm -rf opencv-4.2.0 && rm -rf opencv_contrib-4.2.0 && rm -rf build && \
+	rm -rf opencv-4.10.0 && rm -rf opencv_contrib-4.10.0 && rm -rf build && \
 	rm -rf /var/lib/apt/lists/*
 
 #------------------------------	#
@@ -49,8 +49,7 @@ RUN git clone --branch 2.2.0 --single-branch https://github.com/ceres-solver/cer
 
 # Install python requirements for python_utils scripts
 RUN --mount=type=bind,source=python_utils/requirements_prod.txt,target=/tmp/requirements.txt \
-    apt update && apt install -y libgl1 && \
-    python -m pip install --requirement /tmp/requirements.txt && \
+    python -m pip install --requirement /tmp/requirements.txt --break-system-packages && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM prod as dev
@@ -75,5 +74,5 @@ RUN apt update && apt install -y cppcheck clang-tidy valgrind lcov && \
 
 # Install python requirements for python_utils scripts
 RUN --mount=type=bind,source=python_utils/requirements_dev.txt,target=/tmp/requirements.txt \
-    python -m pip install --requirement /tmp/requirements.txt && \
+    python -m pip install --requirement /tmp/requirements.txt --break-system-packages && \
 	rm -rf /var/lib/apt/lists/*

--- a/McCalib/include/Board.hpp
+++ b/McCalib/include/Board.hpp
@@ -44,7 +44,7 @@ public:
   std::map<int, std::weak_ptr<Frame>> frames_;
 
   // Charuco board
-  cv::Ptr<cv::aruco::CharucoBoard> charuco_board_; // vector of charuco boards
+  cv::Ptr<cv::aruco::CharucoBoard> charuco_board_;
 
   // Functions
   Board() = delete;

--- a/McCalib/include/McCalib.hpp
+++ b/McCalib/include/McCalib.hpp
@@ -36,11 +36,22 @@ class Calibration final {
 public:
   // Parameters
   unsigned int nb_camera_, nb_board_;
+
+#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
+     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
   cv::Ptr<cv::aruco::Dictionary> dict_ = cv::aruco::getPredefinedDictionary(
       cv::aruco::DICT_6X6_1000); // load the dictionary that correspond to the
                                  // charuco board
   cv::Ptr<cv::aruco::DetectorParameters> charuco_params_ =
       cv::aruco::DetectorParameters::create(); // parameters for detection
+#else
+  cv::aruco::Dictionary dict_ = cv::aruco::getPredefinedDictionary(
+      cv::aruco::DICT_6X6_1000); // load the dictionary that correspond to the
+                                 // charuco board
+  cv::aruco::DetectorParameters charuco_params_ =
+      cv::aruco::DetectorParameters(); // parameters for detection
+#endif
+
   float min_perc_pts_;
 
   // images path

--- a/McCalib/include/point_refinement.h
+++ b/McCalib/include/point_refinement.h
@@ -1,13 +1,15 @@
-#include "opencv2/core/core.hpp"
+#include <cmath>
 #include <iostream>
-#include <opencv2/opencv.hpp>
 #include <stdio.h>
+
+#include "opencv2/core/core.hpp"
+#include <opencv2/opencv.hpp>
 
 namespace McCalib {
 
 /****** ******/
 
-float step_threshold = 0.001;
+double step_threshold = 0.001;
 
 /**
  * @struct SaddlePoint
@@ -36,7 +38,7 @@ void initSaddlePointRefinement(const int half_kernel_size,
   int cnt = 0;
   for (int y = -half_kernel_size; y <= half_kernel_size; y++)
     for (int x = -half_kernel_size; x <= half_kernel_size; x++) {
-      *w = maxVal - sqrt(x * x + y * y);
+      *w = maxVal - std::sqrt(x * x + y * y);
       if (*w > 0)
         cnt++;
       else
@@ -138,22 +140,23 @@ void saddleSubpixelRefinement(const cv::Mat &smooth_input,
                     pt.det; //       k3 * k1 - 2 * k5 * k2
         pt.x += dx;
         pt.y += dy;
-        dx = fabs(dx);
-        dy = fabs(dy);
+        dx = std::fabs(dx);
+        dy = std::fabs(dy);
         // iterations++;
 
         if (it == max_iterations ||
             (step_threshold > dx && step_threshold > dy)) {
           // converged
           double k4mk5 = r[1] - r[0];
-          pt.s = sqrt(r[2] * r[2] + k4mk5 * k4mk5);
-          pt.a1 = atan2(-r[2], k4mk5) / 2.0;
-          pt.a2 = acos((r[1] + r[0]) / pt.s) / 2.0;
+          pt.s = std::sqrt(r[2] * r[2] + k4mk5 * k4mk5);
+          pt.a1 = std::atan2(-r[2], k4mk5) / 2.0;
+          pt.a2 = std::acos((r[1] + r[0]) / pt.s) / 2.0;
           break;
         } else {
           // check for divergence
-          if (pt.det > 0 || fabs(pt.x - initial[idx].x) > window_half_size ||
-              fabs(pt.y - initial[idx].y) > window_half_size) {
+          if (pt.det > 0 ||
+              std::fabs(pt.x - initial[idx].x) > window_half_size ||
+              std::fabs(pt.y - initial[idx].y) > window_half_size) {
             pt.x = pt.y = std::numeric_limits<double>::infinity();
             // diverged++;
             break;

--- a/McCalib/include/utilities.hpp
+++ b/McCalib/include/utilities.hpp
@@ -1,12 +1,42 @@
 
 #include <filesystem>
+#include <map>
 #include <string>
 #include <vector>
+
+#include <opencv2/aruco/charuco.hpp>
+#include <opencv2/opencv.hpp>
 
 namespace McCalib {
 
 std::filesystem::path convertStrToPath(const std::string &item_name);
 std::vector<std::filesystem::path>
 convertVecStrToVecPath(const std::vector<std::string> &input);
+
+#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
+     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+
+std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
+createCharucoBoards(const unsigned int num_board,
+                    const std::vector<int> &number_x_square_per_board,
+                    const std::vector<int> &number_y_square_per_board,
+                    const float length_square, const float length_marker,
+                    const cv::Ptr<cv::aruco::Dictionary> dict);
+#else
+std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
+createCharucoBoards(const unsigned int num_board,
+                    const std::vector<int> &number_x_square_per_board,
+                    const std::vector<int> &number_y_square_per_board,
+                    const float length_square, const float length_marker,
+                    const cv::aruco::Dictionary &dict);
+#endif
+
+std::vector<cv::Mat>
+createCharucoBoardsImages(const unsigned int num_board,
+                          const std::vector<int> &number_x_square_per_board,
+                          const std::vector<int> &number_y_square_per_board,
+                          const float length_square, const float length_marker,
+                          const std::vector<int> &resolution_x_per_board,
+                          const std::vector<int> &resolution_y_per_board);
 
 } // namespace McCalib

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -1,8 +1,11 @@
-#include "opencv2/core/core.hpp"
+#include <algorithm>
 #include <iostream>
+#include <random>
+#include <stdio.h>
+
+#include "opencv2/core/core.hpp"
 #include <opencv2/aruco/charuco.hpp>
 #include <opencv2/opencv.hpp>
-#include <stdio.h>
 
 #include "Camera.hpp"
 #include "OptimizationCeres.h"
@@ -169,7 +172,9 @@ void Camera::initializeCalibration() {
   std::srand(unsigned(std::time(0)));
   std::vector<int> shuffled_board_ind(indbv.size());
   std::iota(shuffled_board_ind.begin(), shuffled_board_ind.end(), 0);
-  random_shuffle(shuffled_board_ind.begin(), shuffled_board_ind.end());
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(shuffled_board_ind.begin(), shuffled_board_ind.end(), g);
 
   // nb of boards used for the initial estimation of intrinsic parameters
   //(at least 50 boards for perspective)

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -1,6 +1,8 @@
 #include "opencv2/core/core.hpp"
+#include <algorithm>
 #include <iostream>
 #include <opencv2/opencv.hpp>
+#include <random>
 #include <stdio.h>
 
 #include "geometrytools.hpp"
@@ -169,7 +171,9 @@ void ransacTriangulation(const std::vector<cv::Point2f> &point2d,
   // Ransac iterations
   while (N > trialcount && countit < it) {
     // pick 2 points
-    std::random_shuffle(myvector.begin(), myvector.end());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(myvector.begin(), myvector.end(), g);
     std::array<int, 4> idx = {myvector[0], myvector[1], myvector[2],
                               myvector[3]};
 
@@ -249,9 +253,10 @@ cv::Mat ransacP3P(const std::vector<cv::Point3f> &scenePoints,
 
   // Ransac iterations
   while (N > trialcount && countit < it) {
-
     // pick 4 points
-    std::random_shuffle(myvector.begin(), myvector.end());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(myvector.begin(), myvector.end(), g);
     std::array<int, 4> idx = {myvector[0], myvector[1], myvector[2],
                               myvector[3]};
 

--- a/McCalib/src/utilities.cpp
+++ b/McCalib/src/utilities.cpp
@@ -1,5 +1,7 @@
 #include "utilities.hpp"
 
+#include <numeric>
+
 namespace McCalib {
 
 std::filesystem::path convertStrToPath(const std::string &item_name) {
@@ -17,5 +19,131 @@ convertVecStrToVecPath(const std::vector<std::string> &input) {
   }
   return out;
 }
+
+#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
+     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+
+std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
+createCharucoBoards(const unsigned int num_board,
+                    const std::vector<int> &number_x_square_per_board,
+                    const std::vector<int> &number_y_square_per_board,
+                    const float length_square, const float length_marker,
+                    const cv::Ptr<cv::aruco::Dictionary> dict) {
+  std::map<int, cv::Ptr<cv::aruco::CharucoBoard>> charuco_boards;
+  int offset_count = 0;
+  for (std::size_t i = 0; i < num_board; i++) {
+    // declare the board
+    cv::Ptr<cv::aruco::CharucoBoard> charuco = cv::aruco::CharucoBoard::create(
+        number_x_square_per_board[i], number_y_square_per_board[i],
+        length_square, length_marker, dict);
+    // If it is the first board then just use the standard idx
+    if (i != 0) {
+      int id_offset = charuco_boards[i - 1]->ids.size() + offset_count;
+      offset_count = id_offset;
+      for (auto &id : charuco->ids) {
+        id += id_offset;
+      }
+    }
+    charuco_boards[i] = charuco;
+  }
+  assert(charuco_boards.size() == num_board);
+  return charuco_boards;
+}
+
+std::vector<cv::Mat>
+createCharucoBoardsImages(const unsigned int num_board,
+                          const std::vector<int> &number_x_square_per_board,
+                          const std::vector<int> &number_y_square_per_board,
+                          const float length_square, const float length_marker,
+                          const std::vector<int> &resolution_x_per_board,
+                          const std::vector<int> &resolution_y_per_board) {
+  cv::Ptr<cv::aruco::Dictionary> dict =
+      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
+  const std::map<int, cv::Ptr<cv::aruco::CharucoBoard>> charuco_boards =
+      createCharucoBoards(num_board, number_x_square_per_board,
+                          number_y_square_per_board, length_square,
+                          length_marker, dict);
+
+  std::vector<cv::Mat> charuco_boards_images;
+  charuco_boards_images.reserve(num_board);
+  for (std::size_t i = 0u; i < charuco_boards.size(); ++i) {
+    // create the charuco board image
+    cv::Mat board_image;
+    for (auto const &charuco_board_iter : charuco_boards) {
+      charuco_board_iter.second->draw(
+          cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
+          board_image, 10, 1);
+      charuco_boards_images.push_back(board_image);
+    }
+  }
+  return charuco_boards_images;
+}
+
+#else
+
+std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
+createCharucoBoards(const unsigned int num_board,
+                    const std::vector<int> &number_x_square_per_board,
+                    const std::vector<int> &number_y_square_per_board,
+                    const float length_square, const float length_marker,
+                    const cv::aruco::Dictionary &dict) {
+  std::map<int, cv::Ptr<cv::aruco::CharucoBoard>> charuco_boards;
+  int offset_count = 0;
+  for (std::size_t i = 0; i < num_board; i++) {
+    if (i == 0) {
+      // if it is the first board then just use the standard idx
+      charuco_boards[i] = cv::makePtr<cv::aruco::CharucoBoard>(
+          cv::aruco::CharucoBoard(cv::Size(number_x_square_per_board[i],
+                                           number_y_square_per_board[i]),
+                                  length_square, length_marker, dict));
+    } else {
+      int id_offset = charuco_boards[i - 1]->getIds().size() + offset_count;
+      offset_count = id_offset;
+
+      const std::size_t num_idxs = charuco_boards[i - 1]->getIds().size();
+      std::vector<int> cur_ids(num_idxs);
+      std::iota(cur_ids.begin(), cur_ids.end(), id_offset);
+
+      charuco_boards[i] = cv::makePtr<cv::aruco::CharucoBoard>(
+          cv::aruco::CharucoBoard(cv::Size(number_x_square_per_board[i],
+                                           number_y_square_per_board[i]),
+                                  length_square, length_marker, dict, cur_ids));
+    }
+  }
+  assert(charuco_boards.size() == num_board);
+  return charuco_boards;
+}
+
+std::vector<cv::Mat>
+createCharucoBoardsImages(const unsigned int num_board,
+                          const std::vector<int> &number_x_square_per_board,
+                          const std::vector<int> &number_y_square_per_board,
+                          const float length_square, const float length_marker,
+                          const std::vector<int> &resolution_x_per_board,
+                          const std::vector<int> &resolution_y_per_board) {
+  const cv::aruco::Dictionary dict =
+      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
+  const std::map<int, cv::Ptr<cv::aruco::CharucoBoard>> charuco_boards =
+      createCharucoBoards(num_board, number_x_square_per_board,
+                          number_y_square_per_board, length_square,
+                          length_marker, dict);
+
+  std::vector<cv::Mat> charuco_boards_images;
+  charuco_boards_images.reserve(num_board);
+  for (std::size_t i = 0u; i < charuco_boards.size(); ++i) {
+    // create the charuco board image
+    cv::Mat board_image;
+    for (auto const &charuco_board_iter : charuco_boards) {
+      charuco_board_iter.second->generateImage(
+          cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
+          board_image, 10, 1);
+      charuco_boards_images.push_back(board_image);
+    }
+  }
+
+  return charuco_boards_images;
+}
+
+#endif
 
 } // namespace McCalib

--- a/McCalib/src/utilities.cpp
+++ b/McCalib/src/utilities.cpp
@@ -66,15 +66,12 @@ createCharucoBoardsImages(const unsigned int num_board,
 
   std::vector<cv::Mat> charuco_boards_images;
   charuco_boards_images.reserve(num_board);
-  for (std::size_t i = 0u; i < charuco_boards.size(); ++i) {
-    // create the charuco board image
+  for (auto const &[i, charuco_board] : charuco_boards) {
     cv::Mat board_image;
-    for (auto const &charuco_board_iter : charuco_boards) {
-      charuco_board_iter.second->draw(
-          cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
-          board_image, 10, 1);
-      charuco_boards_images.push_back(board_image);
-    }
+    charuco_board->draw(
+        cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
+        board_image, 10, 1);
+    charuco_boards_images.push_back(board_image);
   }
   return charuco_boards_images;
 }
@@ -130,15 +127,12 @@ createCharucoBoardsImages(const unsigned int num_board,
 
   std::vector<cv::Mat> charuco_boards_images;
   charuco_boards_images.reserve(num_board);
-  for (std::size_t i = 0u; i < charuco_boards.size(); ++i) {
-    // create the charuco board image
+  for (auto const &[i, charuco_board] : charuco_boards) {
     cv::Mat board_image;
-    for (auto const &charuco_board_iter : charuco_boards) {
-      charuco_board_iter.second->generateImage(
-          cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
-          board_image, 10, 1);
-      charuco_boards_images.push_back(board_image);
-    }
+    charuco_board->generateImage(
+        cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
+        board_image, 10, 1);
+    charuco_boards_images.push_back(board_image);
   }
 
   return charuco_boards_images;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Toolbox described in the paper ["MC-Calib: A generic and robust calibration tool
 
 # Installation
 
-Requirements: Ceres, Boost, OpenCV 4.2.0, c++17 
+Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0}, c++17 
 
 For Windows users, follow [this installation guide](/docs/Windows.md)
 
@@ -20,8 +20,8 @@ There are several ways to get the environment ready. Choose any of them:
    - Pull the image:
 
      ```bash
-     docker pull bailool/mc-calib-prod:opencv420 # production environment
-     docker pull bailool/mc-calib-dev:opencv420  # development environment
+     docker pull bailool/mc-calib-prod:opencv4100 # production environment
+     docker pull bailool/mc-calib-dev:opencv4100  # development environment
      ```
 
    - Run pulled image (set `PATH_TO_REPO_ROOT` and `PATH_TO_DATA` appropriately):
@@ -31,7 +31,7 @@ There are several ways to get the environment ready. Choose any of them:
                   -ti --rm \
                   --volume="$PATH_TO_REPO_ROOT:/home/MC-Calib" \
                   --volume="$PATH_TO_DATA:/home/MC-Calib/data" \
-                  bailool/mc-calib-prod:opencv420
+                  bailool/mc-calib-prod:opencv4100
       ```
       
 2. It is also possible to build the docker environment manually (see [instructions](/docs/Docker.md))

--- a/apps/create_charuco_boards/CMakeLists.txt
+++ b/apps/create_charuco_boards/CMakeLists.txt
@@ -3,4 +3,4 @@ set(SOURCES
 )
 
 add_executable(generate_charuco ${SOURCES})
-target_link_libraries(generate_charuco -L/usr/local/lib ${OpenCV_LIBS})
+target_link_libraries(generate_charuco -L/usr/local/lib ${OpenCV_LIBS} McCalib)

--- a/apps/create_charuco_boards/src/create_charuco_boards.cpp
+++ b/apps/create_charuco_boards/src/create_charuco_boards.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
 
   fs["number_board"] >> NbBoard;
   assert(NbBoard > 0);
-  const unsigned int num_board = static_cast<int>(NbBoard);
+  const unsigned int num_board = static_cast<unsigned int>(NbBoard);
 
   fs["square_size_per_board"] >> square_size_per_board;
   fs["number_x_square_per_board"] >> number_x_square_per_board;

--- a/apps/create_charuco_boards/src/create_charuco_boards.cpp
+++ b/apps/create_charuco_boards/src/create_charuco_boards.cpp
@@ -1,105 +1,11 @@
 #include <filesystem>
 #include <iomanip>
-#include <numeric>
 #include <stdio.h>
 
-#include <opencv2/aruco/charuco.hpp>
 #include <opencv2/opencv.hpp>
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
-
-std::vector<cv::Mat>
-createCharucoBoards(const unsigned int num_board,
-                    const std::vector<int> &number_x_square_per_board,
-                    const std::vector<int> &number_y_square_per_board,
-                    const float length_square, const float length_marker,
-                    const std::vector<int> &resolution_x_per_board,
-                    const std::vector<int> &resolution_y_per_board) {
-  std::vector<cv::Mat> charuco_boards_images;
-  charuco_boards_images.reserve(num_board);
-  cv::Ptr<cv::aruco::Dictionary> dict =
-      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
-  std::vector<cv::Ptr<cv::aruco::CharucoBoard>> charuco_boards;
-  charuco_boards.reserve(num_board);
-  int offset_count = 0;
-  for (std::size_t i = 0; i < num_board; i++) {
-    // declare the board
-    cv::Ptr<cv::aruco::CharucoBoard> charuco = cv::aruco::CharucoBoard::create(
-        number_x_square_per_board[i], number_y_square_per_board[i],
-        length_square, length_marker, dict);
-    // If it is the first board then just use the standard idx
-    if (i != 0) {
-      int id_offset = charuco_boards[i - 1]->ids.size() + offset_count;
-      offset_count = id_offset;
-      for (auto &id : charuco->ids) {
-        id += id_offset;
-      }
-    }
-    charuco_boards.push_back(charuco);
-
-    // create the charuco board image
-    cv::Mat board_image;
-    charuco_boards[i]->draw(
-        cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
-        board_image, 10, 1);
-
-    charuco_boards_images.push_back(board_image);
-  }
-  return charuco_boards_images;
-}
-
-#else
-
-std::vector<cv::Mat>
-createCharucoBoards(const unsigned int num_board,
-                    const std::vector<int> &number_x_square_per_board,
-                    const std::vector<int> &number_y_square_per_board,
-                    const float length_square, const float length_marker,
-                    const std::vector<int> &resolution_x_per_board,
-                    const std::vector<int> &resolution_y_per_board) {
-  std::vector<cv::Mat> charuco_boards_images;
-  charuco_boards_images.reserve(num_board);
-  const cv::aruco::Dictionary dict =
-      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_1000);
-  std::vector<cv::aruco::CharucoBoard> charuco_boards;
-  charuco_boards.reserve(num_board);
-  int offset_count = 0;
-  for (std::size_t i = 0; i < num_board; i++) {
-    if (i == 0) {
-      // if it is the first board then just use the standard idx
-      cv::aruco::CharucoBoard charuco = cv::aruco::CharucoBoard(
-          cv::Size(number_x_square_per_board[i], number_y_square_per_board[i]),
-          length_square, length_marker, dict);
-
-      charuco_boards.push_back(charuco);
-    } else {
-      int id_offset = charuco_boards[i - 1].getIds().size() + offset_count;
-      offset_count = id_offset;
-
-      const std::size_t num_idxs = charuco_boards[i - 1].getIds().size();
-      std::vector<int> cur_ids(num_idxs);
-      std::iota(cur_ids.begin(), cur_ids.end(), id_offset);
-
-      cv::aruco::CharucoBoard charuco = cv::aruco::CharucoBoard(
-          cv::Size(number_x_square_per_board[i], number_y_square_per_board[i]),
-          length_square, length_marker, dict, cur_ids);
-
-      charuco_boards.push_back(charuco);
-    }
-
-    // create the charuco board image
-    cv::Mat board_image;
-    charuco_boards[i].generateImage(
-        cv::Size(resolution_x_per_board[i], resolution_y_per_board[i]),
-        board_image, 10, 1);
-
-    charuco_boards_images.push_back(board_image);
-  }
-
-  return charuco_boards_images;
-}
-#endif
+#include "McCalib.hpp"
+#include "utilities.hpp"
 
 void saveBoards(const std::vector<cv::Mat> boards) {
   for (std::size_t board_idx = 0u; board_idx < boards.size(); ++board_idx) {
@@ -170,10 +76,11 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  const std::vector<cv::Mat> charuco_boards_images = createCharucoBoards(
-      num_board, number_x_square_per_board, number_y_square_per_board,
-      length_square, length_marker, resolution_x_per_board,
-      resolution_y_per_board);
+  const std::vector<cv::Mat> charuco_boards_images =
+      McCalib::createCharucoBoardsImages(
+          num_board, number_x_square_per_board, number_y_square_per_board,
+          length_square, length_marker, resolution_x_per_board,
+          resolution_y_per_board);
   saveBoards(charuco_boards_images);
 
   return 0;

--- a/apps/create_charuco_boards/src/create_charuco_boards.cpp
+++ b/apps/create_charuco_boards/src/create_charuco_boards.cpp
@@ -8,17 +8,21 @@
 #include "utilities.hpp"
 
 void saveBoards(const std::vector<cv::Mat> boards) {
+  std::filesystem::path charuco_boards_path = "charuco_boards";
+  std::string char_name = "charuco_board_";
+  std::string ext_name = ".bmp";
+  if (!std::filesystem::exists(charuco_boards_path)) {
+    std::filesystem::create_directories(charuco_boards_path);
+  }
   for (std::size_t board_idx = 0u; board_idx < boards.size(); ++board_idx) {
     // Save the markers
     std::ostringstream ss;
     ss << std::setw(3) << std::setfill('0') << board_idx;
     std::string s1 = ss.str();
-    std::string charname = "charuco_board_";
-    std::string extname = ".bmp";
-    std::string savename = charname + s1;
-    savename += extname;
-    std::cout << "save_name " << savename << std::endl;
-    cv::imwrite(savename, boards[board_idx]);
+    std::string save_name = char_name + s1 + ext_name;
+    std::filesystem::path save_path = charuco_boards_path / save_name;
+    std::cout << "save_name: " << save_path << std::endl;
+    cv::imwrite(save_path, boards[board_idx]);
   }
 }
 

--- a/python_utils/requirements_dev.txt
+++ b/python_utils/requirements_dev.txt
@@ -1,4 +1,4 @@
 isort==5.13.2
-black==24.4.2
-mypy==1.10.0
-pylint==3.2.2
+black==24.8.0
+mypy==1.11.2
+pylint==3.2.6

--- a/python_utils/requirements_prod.txt
+++ b/python_utils/requirements_prod.txt
@@ -1,3 +1,3 @@
-numpy==1.24.4
-matplotlib==3.7.5
-opencv-python==4.9.0.80
+numpy==2.1.0
+matplotlib==3.9.2
+opencv-python==4.10.0.84

--- a/tests/test_calibration.cpp
+++ b/tests/test_calibration.cpp
@@ -11,9 +11,9 @@
 
 #define PI 3.14159265
 
-const double INTRINSICS_TOLERANCE = 4.0;          // in percentage
-const double TRANSLATION_ERROR_TOLERANCE = 0.005; // in meters
-const double ROTATION_ERROR_TOLERANCE = 1.0;      // in degrees
+constexpr double INTRINSICS_TOLERANCE = 4.0;          // in percentage
+constexpr double TRANSLATION_ERROR_TOLERANCE = 0.005; // in meters
+constexpr double ROTATION_ERROR_TOLERANCE = 1.0;      // in degrees
 
 double getTranslationError(cv::Mat a, cv::Mat b) {
   double dist = cv::norm(a, b, cv::NORM_L2);

--- a/tests/test_calibration.cpp
+++ b/tests/test_calibration.cpp
@@ -11,9 +11,9 @@
 
 #define PI 3.14159265
 
-double INTRINSICS_TOLERANCE = 4.0;          // in percentage
-double TRANSLATION_ERROR_TOLERANCE = 0.005; // in meters
-double ROTATION_ERROR_TOLERANCE = 1.0;      // in degrees
+const double INTRINSICS_TOLERANCE = 4.0;          // in percentage
+const double TRANSLATION_ERROR_TOLERANCE = 0.005; // in meters
+const double ROTATION_ERROR_TOLERANCE = 1.0;      // in degrees
 
 double getTranslationError(cv::Mat a, cv::Mat b) {
   double dist = cv::norm(a, b, cv::NORM_L2);
@@ -60,7 +60,10 @@ void calibrate(McCalib::Calibration &Calib) {
 }
 
 void calibrateAndCheckGt(const std::filesystem::path &config_path,
-                         const std::filesystem::path &gt_path) {
+                         const std::filesystem::path &gt_path,
+                         const double intrinsics_tolerance,
+                         const double translation_error_tolerance,
+                         const double rotation_error_tolerance) {
   McCalib::Calibration Calib(config_path);
   calibrate(Calib);
 
@@ -110,12 +113,12 @@ void calibrateAndCheckGt(const std::filesystem::path &config_path,
     double rot_error = getRotationError(rot_pred, rot_gt);
 
     // perform verifications
-    BOOST_CHECK_CLOSE(fx_pred, fx_gt, INTRINSICS_TOLERANCE);
-    BOOST_CHECK_CLOSE(fy_pred, fy_gt, INTRINSICS_TOLERANCE);
-    BOOST_CHECK_CLOSE(cx_pred, cx_gt, INTRINSICS_TOLERANCE);
-    BOOST_CHECK_CLOSE(cy_pred, cy_gt, INTRINSICS_TOLERANCE);
-    BOOST_CHECK_SMALL(tran_error, TRANSLATION_ERROR_TOLERANCE);
-    BOOST_CHECK_SMALL(rot_error, ROTATION_ERROR_TOLERANCE);
+    BOOST_CHECK_CLOSE(fx_pred, fx_gt, intrinsics_tolerance);
+    BOOST_CHECK_CLOSE(fy_pred, fy_gt, intrinsics_tolerance);
+    BOOST_CHECK_CLOSE(cx_pred, cx_gt, intrinsics_tolerance);
+    BOOST_CHECK_CLOSE(cy_pred, cy_gt, intrinsics_tolerance);
+    BOOST_CHECK_SMALL(tran_error, translation_error_tolerance);
+    BOOST_CHECK_SMALL(rot_error, rotation_error_tolerance);
   }
 }
 
@@ -134,7 +137,8 @@ BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario1) {
       "../data/Blender_Images/Scenario_1/GroundTruth.yml";
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(config_path), true);
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(gt_path), true);
-  calibrateAndCheckGt(config_path, gt_path);
+  calibrateAndCheckGt(config_path, gt_path, INTRINSICS_TOLERANCE,
+                      TRANSLATION_ERROR_TOLERANCE, ROTATION_ERROR_TOLERANCE);
 }
 
 BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario2) {
@@ -144,7 +148,8 @@ BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario2) {
       "../data/Blender_Images/Scenario_2/GroundTruth.yml";
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(config_path), true);
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(gt_path), true);
-  calibrateAndCheckGt(config_path, gt_path);
+  calibrateAndCheckGt(config_path, gt_path, INTRINSICS_TOLERANCE,
+                      TRANSLATION_ERROR_TOLERANCE, ROTATION_ERROR_TOLERANCE);
 }
 
 BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario3) {
@@ -154,7 +159,8 @@ BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario3) {
       "../data/Blender_Images/Scenario_3/GroundTruth.yml";
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(config_path), true);
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(gt_path), true);
-  calibrateAndCheckGt(config_path, gt_path);
+  calibrateAndCheckGt(config_path, gt_path, INTRINSICS_TOLERANCE,
+                      TRANSLATION_ERROR_TOLERANCE, ROTATION_ERROR_TOLERANCE);
 }
 
 BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario4) {
@@ -164,7 +170,8 @@ BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario4) {
       "../data/Blender_Images/Scenario_4/GroundTruth.yml";
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(config_path), true);
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(gt_path), true);
-  calibrateAndCheckGt(config_path, gt_path);
+  calibrateAndCheckGt(config_path, gt_path, INTRINSICS_TOLERANCE,
+                      TRANSLATION_ERROR_TOLERANCE, ROTATION_ERROR_TOLERANCE);
 }
 
 BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario5) {
@@ -174,7 +181,9 @@ BOOST_AUTO_TEST_CASE(CheckCalibrationSyntheticScenario5) {
       "../data/Blender_Images/Scenario_5/GroundTruth.yml";
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(config_path), true);
   BOOST_REQUIRE_EQUAL(std::filesystem::exists(gt_path), true);
-  calibrateAndCheckGt(config_path, gt_path);
+  calibrateAndCheckGt(config_path, gt_path, INTRINSICS_TOLERANCE,
+                      3 * TRANSLATION_ERROR_TOLERANCE,
+                      ROTATION_ERROR_TOLERANCE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- [x] Add support for OpenCV > v4.6.0
- [x] Run CI tests with different OpenCV versions {4.2.0, 4.5.5, 4.10.0}
- [x] CI to use OpenCV v4.10.0 as the base (`opencv4100` tag)
- [x] Add CI jobs to generate charuco boards
- [x] Update README (`opencv4100` tag)
- [x] Update Dockerfile

Closes #80 