### PR TITLE
Add Double Sphere camera model: projection, unprojection, and storage

### DIFF
--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -43,7 +43,7 @@ public:
   // intrinsics
   // fx,fy,u0,v0,r1,r2,t1,t2,r3 (perspective)
   // fx,fy,u0,v0,k1,k2,k3,k4 (Kannala)
-  std::array<double, 9> intrinsics_;
+  std::array<double, 9> intrinsics_{};
 
   int cam_idx_ = 0; // camera index
   int distortion_model_ = 0;
@@ -65,6 +65,8 @@ public:
   void getIntrinsics(cv::Mat &K, cv::Mat &distortion_vector);
   void setIntrinsics(const cv::Mat &K, const cv::Mat &distortion_vector);
   bool checkBorderToleranceFisheye(const std::shared_ptr<BoardObs> board_obs);
+  void dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                   std::vector<cv::Point3f> &rays) const;
 };
 
 } // namespace McCalib

--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -41,8 +41,12 @@ public:
   std::vector<int> vis_object_idx_; // vector of index of the 3D object
 
   // intrinsics
-  // fx,fy,u0,v0,r1,r2,t1,t2,r3 (perspective)
-  // fx,fy,u0,v0,k1,k2,k3,k4 (Kannala)
+  // Indices [0..3] always store fx, fy, u0, v0 (filled by setCameraMat).
+  // Indices [4..] store the distortion parameters, layout depends on model:
+  //   fx,fy,u0,v0,r1,r2,t1,t2,r3 (perspective / Brown, distortion_model_ == 0)
+  //   fx,fy,u0,v0,k1,k2,k3,k4    (Kannala,          distortion_model_ == 1)
+  //   fx,fy,u0,v0,xi,alpha       (Double Sphere,    distortion_model_ == 2)
+  // Unused trailing slots remain zero (zero-initialized).
   std::array<double, 9> intrinsics_{};
 
   int cam_idx_ = 0; // camera index

--- a/McCalib/include/geometrytools.hpp
+++ b/McCalib/include/geometrytools.hpp
@@ -8,6 +8,10 @@
 
 namespace McCalib {
 
+// Shared epsilon for guarding against near-zero denominators in projection /
+// unprojection math (Double Sphere model, and related geometric operations).
+inline constexpr double kProjectionEpsilon = 1e-10;
+
 cv::Mat RT2Proj(const cv::Mat &R, const cv::Mat &T);
 cv::Mat RVecT2Proj(const cv::Mat &RVec, const cv::Mat &T);
 cv::Mat RVecT2ProjInt(const cv::Mat &RVec, const cv::Mat &T, const cv::Mat &K);

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -9,7 +9,10 @@
 
 #include "Camera.hpp"
 #include "OptimizationCeres.h"
+#include "geometrytools.hpp"
 #include "logger.h"
+
+#include <cassert>
 
 namespace McCalib {
 
@@ -46,10 +49,15 @@ void Camera::setCameraMat(const cv::Mat &camera_matrix) {
 /**
  * @brief Set the distortion parameters in the intrinsics vector
  *
- * Two distortion models supported:
- *  - Brown: 1x5 distortion vector (radial_1, radial_2, tangential_1,
- * tangential_2, radial_3)
- *  - Kannala: 1x4 distortion vector
+ * Indices [0..3] of intrinsics_ (fx, fy, u0, v0) are expected to be set
+ * separately via setCameraMat(). This function only writes indices [4..].
+ *
+ * Supported distortion models:
+ *  - Brown (distortion_model_ == 0): 1x5 distortion vector
+ *    (radial_1, radial_2, tangential_1, tangential_2, radial_3)
+ *  - Kannala (distortion_model_ == 1): 1x4 distortion vector
+ *  - Double Sphere (distortion_model_ == 2): 1x2 distortion vector (xi, alpha),
+ *    written into intrinsics_[4] and intrinsics_[5]; trailing slots remain 0.
  *
  * @param distortion_vector
  */
@@ -75,7 +83,11 @@ void Camera::setDistortionVector(const cv::Mat &distortion_vector) {
 /**
  * @brief Get the distortion parameters
  *
- * @return distortion vector (Brown or Kannala) following OpenCV conventions
+ * Reads indices [4..] of intrinsics_. Indices [0..3] (fx, fy, u0, v0) are the
+ * camera matrix and are accessed separately via getCameraMat().
+ *
+ * @return distortion vector following OpenCV conventions for Brown / Kannala,
+ *         or a 1x2 (xi, alpha) vector for the Double Sphere model.
  *
  * @todo early exit, possible memory leak due to unsupported distorion model
  */
@@ -316,10 +328,14 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
 }
 
 /**
- * @brief Unproject 2D points to 3D rays using Double Sphere model
+ * @brief Unproject 2D points to 3D rays using the Double Sphere camera model
+ *
+ * Closed-form inverse of the Double Sphere projection from:
+ *   Usenko, Demmel, Cremers, "The Double Sphere Camera Model", 3DV 2018.
+ *   https://arxiv.org/abs/1807.08957 (Eq. 41).
  *
  * @param pts_2d input 2D pixel coordinates
- * @param rays output 3D ray directions (unit vectors)
+ * @param rays   output 3D ray directions (unit vectors)
  */
 void Camera::dsUnproject(const std::vector<cv::Point2f> &pts_2d,
                          std::vector<cv::Point3f> &rays) const {
@@ -332,35 +348,35 @@ void Camera::dsUnproject(const std::vector<cv::Point2f> &pts_2d,
   const double cy = intrinsics_[3];
   const double xi = intrinsics_[4];
   const double alpha = intrinsics_[5];
+  assert(fx != 0.0 && fy != 0.0 &&
+         "DS unprojection requires non-zero fx and fy");
 
   for (const auto &pt : pts_2d) {
-    double mx = (pt.x - cx) / fx;
-    double my = (pt.y - cy) / fy;
-    double r2 = mx * mx + my * my;
+    const double mx = (pt.x - cx) / fx;
+    const double my = (pt.y - cy) / fy;
+    const double r2 = mx * mx + my * my;
 
-    // Validity check
-    double s = 1.0 - (2.0 * alpha - 1.0) * r2;
-    if (s < 0)
-      s = 0; // Clamp
+    // Validity check from Usenko et al. 2018: term under sqrt must be >= 0.
+    const double s = std::max(1.0 - (2.0 * alpha - 1.0) * r2, 0.0);
 
-    double mz =
+    const double mz =
         (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
 
-    double mz2 = mz * mz;
-    double denom = mz2 + r2;
-    if (denom < 1e-10)
-      denom = 1e-10;
-    double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+    const double mz2 = mz * mz;
+    const double denom = std::max(mz2 + r2, kProjectionEpsilon);
+    const double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
 
-    double ray_x = k * mx;
-    double ray_y = k * my;
-    double ray_z = k * mz - xi;
+    const double ray_x = k * mx;
+    const double ray_y = k * my;
+    const double ray_z = k * mz - xi;
 
     // Normalize to unit vector
-    double norm = std::sqrt(ray_x * ray_x + ray_y * ray_y + ray_z * ray_z);
-    if (norm > 1e-10) {
-      rays.emplace_back(float(ray_x / norm), float(ray_y / norm),
-                        float(ray_z / norm));
+    const double norm =
+        std::sqrt(ray_x * ray_x + ray_y * ray_y + ray_z * ray_z);
+    if (norm > kProjectionEpsilon) {
+      rays.emplace_back(static_cast<float>(ray_x / norm),
+                        static_cast<float>(ray_y / norm),
+                        static_cast<float>(ray_z / norm));
     } else {
       rays.emplace_back(0.f, 0.f, 1.f);
     }

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -66,6 +66,10 @@ void Camera::setDistortionVector(const cv::Mat &distortion_vector) {
       intrinsics_[intrinIdx] = distortion_vector.at<double>(distIdx);
     }
   }
+  if (distortion_model_ == 2) {                       // Double Sphere
+    intrinsics_[4] = distortion_vector.at<double>(0); // xi
+    intrinsics_[5] = distortion_vector.at<double>(1); // alpha
+  }
 }
 
 /**
@@ -91,6 +95,13 @@ cv::Mat Camera::getDistortionVectorVector() const {
       std::size_t distIdx = intrinIdx - 4u;
       distortion_vector.at<double>(distIdx) = intrinsics_[intrinIdx];
     }
+    return distortion_vector;
+  }
+
+  else if (distortion_model_ == 2) { // Double Sphere
+    cv::Mat distortion_vector = cv::Mat(1, 2, CV_64F, cv::Scalar(0));
+    distortion_vector.at<double>(0) = intrinsics_[4]; // xi
+    distortion_vector.at<double>(1) = intrinsics_[5]; // alpha
     return distortion_vector;
   }
 
@@ -302,6 +313,58 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
   LOG_INFO << "Parameters after optimization :: " << this->getCameraMat();
   LOG_INFO << "distortion vector after optimization :: "
            << getDistortionVectorVector();
+}
+
+/**
+ * @brief Unproject 2D points to 3D rays using Double Sphere model
+ *
+ * @param pts_2d input 2D pixel coordinates
+ * @param rays output 3D ray directions (unit vectors)
+ */
+void Camera::dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                         std::vector<cv::Point3f> &rays) const {
+  rays.clear();
+  rays.reserve(pts_2d.size());
+
+  const double fx = intrinsics_[0];
+  const double fy = intrinsics_[1];
+  const double cx = intrinsics_[2];
+  const double cy = intrinsics_[3];
+  const double xi = intrinsics_[4];
+  const double alpha = intrinsics_[5];
+
+  for (const auto &pt : pts_2d) {
+    double mx = (pt.x - cx) / fx;
+    double my = (pt.y - cy) / fy;
+    double r2 = mx * mx + my * my;
+
+    // Validity check
+    double s = 1.0 - (2.0 * alpha - 1.0) * r2;
+    if (s < 0)
+      s = 0; // Clamp
+
+    double mz =
+        (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
+
+    double mz2 = mz * mz;
+    double denom = mz2 + r2;
+    if (denom < 1e-10)
+      denom = 1e-10;
+    double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+
+    double ray_x = k * mx;
+    double ray_y = k * my;
+    double ray_z = k * mz - xi;
+
+    // Normalize to unit vector
+    double norm = std::sqrt(ray_x * ray_x + ray_y * ray_y + ray_z * ray_z);
+    if (norm > 1e-10) {
+      rays.emplace_back(float(ray_x / norm), float(ray_y / norm),
+                        float(ray_z / norm));
+    } else {
+      rays.emplace_back(0.f, 0.f, 1.f);
+    }
+  }
 }
 
 } // namespace McCalib

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -768,41 +768,41 @@ void projectPointsWithDistortion(const std::vector<cv::Point3f> &object_pts,
     cv::fisheye::projectPoints(object_pts, repro_pts, rot, trans, camera_matrix,
                                distortion_vector, 0.0);
   }
-  if (distortion_type == 2) // Double Sphere
+  if (distortion_type == 2) // Double Sphere (Usenko et al., 3DV 2018)
   {
     cv::Mat R;
     cv::Rodrigues(rot, R);
-    double fx = camera_matrix.at<double>(0, 0);
-    double fy = camera_matrix.at<double>(1, 1);
-    double cx = camera_matrix.at<double>(0, 2);
-    double cy = camera_matrix.at<double>(1, 2);
-    double xi = distortion_vector.at<double>(0);
-    double alpha = distortion_vector.at<double>(1);
+    const double fx = camera_matrix.at<double>(0, 0);
+    const double fy = camera_matrix.at<double>(1, 1);
+    const double cx = camera_matrix.at<double>(0, 2);
+    const double cy = camera_matrix.at<double>(1, 2);
+    const double xi = distortion_vector.at<double>(0);
+    const double alpha = distortion_vector.at<double>(1);
 
-    double tx = trans.at<double>(0);
-    double ty = trans.at<double>(1);
-    double tz = trans.at<double>(2);
+    const double tx = trans.at<double>(0);
+    const double ty = trans.at<double>(1);
+    const double tz = trans.at<double>(2);
 
     repro_pts.reserve(object_pts.size());
     for (const auto &pt : object_pts) {
       // Transform 3D point to camera frame
-      double X = R.at<double>(0, 0) * pt.x + R.at<double>(0, 1) * pt.y +
-                 R.at<double>(0, 2) * pt.z + tx;
-      double Y = R.at<double>(1, 0) * pt.x + R.at<double>(1, 1) * pt.y +
-                 R.at<double>(1, 2) * pt.z + ty;
-      double Z = R.at<double>(2, 0) * pt.x + R.at<double>(2, 1) * pt.y +
-                 R.at<double>(2, 2) * pt.z + tz;
+      const double X = R.at<double>(0, 0) * pt.x + R.at<double>(0, 1) * pt.y +
+                       R.at<double>(0, 2) * pt.z + tx;
+      const double Y = R.at<double>(1, 0) * pt.x + R.at<double>(1, 1) * pt.y +
+                       R.at<double>(1, 2) * pt.z + ty;
+      const double Z = R.at<double>(2, 0) * pt.x + R.at<double>(2, 1) * pt.y +
+                       R.at<double>(2, 2) * pt.z + tz;
 
       // DS Projection
-      double d1 = std::sqrt(X * X + Y * Y + Z * Z);
-      double z1 = Z + xi * d1;
-      double d2 = std::sqrt(X * X + Y * Y + z1 * z1);
-      double den = alpha * d2 + (1.0 - alpha) * z1;
+      const double d1 = std::sqrt(X * X + Y * Y + Z * Z);
+      const double z1 = Z + xi * d1;
+      const double d2 = std::sqrt(X * X + Y * Y + z1 * z1);
+      const double den = alpha * d2 + (1.0 - alpha) * z1;
 
-      if (std::abs(den) > 1e-8) {
-        double u = fx * X / den + cx;
-        double v = fy * Y / den + cy;
-        repro_pts.emplace_back(float(u), float(v));
+      if (std::abs(den) > kProjectionEpsilon) {
+        const double u = fx * X / den + cx;
+        const double v = fy * Y / den + cy;
+        repro_pts.emplace_back(static_cast<float>(u), static_cast<float>(v));
       } else {
         repro_pts.emplace_back(0.f, 0.f);
       }

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -768,6 +768,46 @@ void projectPointsWithDistortion(const std::vector<cv::Point3f> &object_pts,
     cv::fisheye::projectPoints(object_pts, repro_pts, rot, trans, camera_matrix,
                                distortion_vector, 0.0);
   }
+  if (distortion_type == 2) // Double Sphere
+  {
+    cv::Mat R;
+    cv::Rodrigues(rot, R);
+    double fx = camera_matrix.at<double>(0, 0);
+    double fy = camera_matrix.at<double>(1, 1);
+    double cx = camera_matrix.at<double>(0, 2);
+    double cy = camera_matrix.at<double>(1, 2);
+    double xi = distortion_vector.at<double>(0);
+    double alpha = distortion_vector.at<double>(1);
+
+    double tx = trans.at<double>(0);
+    double ty = trans.at<double>(1);
+    double tz = trans.at<double>(2);
+
+    repro_pts.reserve(object_pts.size());
+    for (const auto &pt : object_pts) {
+      // Transform 3D point to camera frame
+      double X = R.at<double>(0, 0) * pt.x + R.at<double>(0, 1) * pt.y +
+                 R.at<double>(0, 2) * pt.z + tx;
+      double Y = R.at<double>(1, 0) * pt.x + R.at<double>(1, 1) * pt.y +
+                 R.at<double>(1, 2) * pt.z + ty;
+      double Z = R.at<double>(2, 0) * pt.x + R.at<double>(2, 1) * pt.y +
+                 R.at<double>(2, 2) * pt.z + tz;
+
+      // DS Projection
+      double d1 = std::sqrt(X * X + Y * Y + Z * Z);
+      double z1 = Z + xi * d1;
+      double d2 = std::sqrt(X * X + Y * Y + z1 * z1);
+      double den = alpha * d2 + (1.0 - alpha) * z1;
+
+      if (std::abs(den) > 1e-8) {
+        double u = fx * X / den + cx;
+        double v = fy * Y / den + cy;
+        repro_pts.emplace_back(float(u), float(v));
+      } else {
+        repro_pts.emplace_back(0.f, 0.f);
+      }
+    }
+  }
 }
 
 cv::Mat convertRotationMatrixToQuaternion(const cv::Mat &R) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package (Boost REQUIRED COMPONENTS unit_test_framework log_setup log REQUIRED)
 
 set(SOURCES
-    main.cpp test_graph.cpp test_calibration.cpp test_geometrytools.cpp simple_unit_tests_example.cpp
+    main.cpp test_graph.cpp test_calibration.cpp test_geometrytools.cpp test_double_sphere.cpp simple_unit_tests_example.cpp
 )
 
 add_executable(boost_tests_run ${SOURCES})

--- a/tests/test_double_sphere.cpp
+++ b/tests/test_double_sphere.cpp
@@ -1,0 +1,349 @@
+#include <boost/test/unit_test.hpp>
+#include <cmath>
+
+#include <Camera.hpp>
+#include <geometrytools.hpp>
+
+BOOST_AUTO_TEST_SUITE(CheckDoubleSphere)
+
+// DS intrinsics: fx, fy, cx, cy, xi, alpha
+static const double DS_FX = 711.574;
+static const double DS_FY = 711.237;
+static const double DS_CX = 960.0;
+static const double DS_CY = 540.0;
+static const double DS_XI = 0.183;
+static const double DS_ALPHA = 0.809;
+
+// Helper: create a Camera with DS intrinsics
+static std::shared_ptr<McCalib::Camera> makeDSCamera() {
+  auto cam = std::make_shared<McCalib::Camera>(0, 2);
+  cam->im_cols_ = 1920;
+  cam->im_rows_ = 1080;
+  cam->intrinsics_[0] = DS_FX;
+  cam->intrinsics_[1] = DS_FY;
+  cam->intrinsics_[2] = DS_CX;
+  cam->intrinsics_[3] = DS_CY;
+  cam->intrinsics_[4] = DS_XI;
+  cam->intrinsics_[5] = DS_ALPHA;
+  return cam;
+}
+
+// Helper: build camera matrix and distortion vector from Camera object
+static void getCameraMatAndDist(const std::shared_ptr<McCalib::Camera> &cam,
+                                cv::Mat &cam_mat, cv::Mat &dist_vec) {
+  cam_mat =
+      (cv::Mat_<double>(3, 3) << cam->intrinsics_[0], 0, cam->intrinsics_[2], 0,
+       cam->intrinsics_[1], cam->intrinsics_[3], 0, 0, 1);
+  dist_vec =
+      (cv::Mat_<double>(1, 2) << cam->intrinsics_[4], cam->intrinsics_[5]);
+}
+
+// ============================================================
+// Test 1: Distortion storage round-trip
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSDistortionStorageRoundTrip) {
+  McCalib::Camera cam(0, 2);
+  cv::Mat dist = (cv::Mat_<double>(1, 2) << 0.183, 0.809);
+  cam.setDistortionVector(dist);
+  cv::Mat dist_out = cam.getDistortionVectorVector();
+  BOOST_CHECK_CLOSE(dist_out.at<double>(0, 0), 0.183, 1e-6);
+  BOOST_CHECK_CLOSE(dist_out.at<double>(0, 1), 0.809, 1e-6);
+}
+
+// ============================================================
+// Test 2: Unused intrinsics slots are zero
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSIntrinsicsZeroInit) {
+  McCalib::Camera cam(0, 2);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[6], 0.0);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[7], 0.0);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[8], 0.0);
+}
+
+// ============================================================
+// Test 3: Projection/Unprojection round-trip for multiple points
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectUnprojectRoundTrip) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  std::vector<cv::Point3f> pts_3d;
+  pts_3d.emplace_back(0.0f, 0.0f, 1.0f);
+  pts_3d.emplace_back(0.1f, -0.05f, 0.8f);
+  pts_3d.emplace_back(-0.2f, 0.15f, 1.2f);
+  pts_3d.emplace_back(0.3f, 0.2f, 0.6f);
+
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    float norm =
+        std::sqrt(pts_3d[i].x * pts_3d[i].x + pts_3d[i].y * pts_3d[i].y +
+                  pts_3d[i].z * pts_3d[i].z);
+    float expected_x = pts_3d[i].x / norm;
+    float expected_y = pts_3d[i].y / norm;
+    float expected_z = pts_3d[i].z / norm;
+
+    BOOST_CHECK_CLOSE(rays[i].x, expected_x, 0.1);
+    BOOST_CHECK_CLOSE(rays[i].y, expected_y, 0.1);
+    BOOST_CHECK_CLOSE(rays[i].z, expected_z, 0.1);
+  }
+}
+
+// ============================================================
+// Test 4: Center point projects to (cx, cy)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectionCenterPoint) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.0f, 0.0f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  BOOST_CHECK_CLOSE(pts_2d[0].x, DS_CX, 0.01);
+  BOOST_CHECK_CLOSE(pts_2d[0].y, DS_CY, 0.01);
+}
+
+// ============================================================
+// Test 5: Unprojecting (cx, cy) gives optical axis [0, 0, 1]
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSUnprojectCenterPoint) {
+  auto cam = makeDSCamera();
+
+  std::vector<cv::Point2f> pts_2d = {
+      cv::Point2f(static_cast<float>(DS_CX), static_cast<float>(DS_CY))};
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  BOOST_CHECK_SMALL(double(rays[0].x), 1e-6);
+  BOOST_CHECK_SMALL(double(rays[0].y), 1e-6);
+  BOOST_CHECK_CLOSE(double(rays[0].z), 1.0, 0.01);
+}
+
+// ============================================================
+// Test 6: DS projection with non-identity pose
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectionWithPose) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // Board-like pattern
+  std::vector<cv::Point3f> pts_3d;
+  for (int r = 0; r < 4; r++) {
+    for (int c = 0; c < 6; c++) {
+      pts_3d.emplace_back(c * 0.055f, r * 0.055f, 0.0f);
+    }
+  }
+
+  // Pose: slight rotation + translation
+  cv::Mat rvec = (cv::Mat_<double>(3, 1) << 0.1, -0.2, 0.15);
+  cv::Mat tvec = (cv::Mat_<double>(3, 1) << 0.05, -0.03, 0.8);
+
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  // All projected points should be within image bounds
+  for (const auto &pt : pts_2d) {
+    BOOST_CHECK_GE(pt.x, 0.0f);
+    BOOST_CHECK_LE(pt.x, 1920.0f);
+    BOOST_CHECK_GE(pt.y, 0.0f);
+    BOOST_CHECK_LE(pt.y, 1080.0f);
+  }
+
+  // Unproject and verify round-trip
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+  BOOST_CHECK_EQUAL(rays.size(), pts_2d.size());
+
+  // Transform original points to camera frame for direction comparison
+  cv::Mat R;
+  cv::Rodrigues(rvec, R);
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    double X = R.at<double>(0, 0) * pts_3d[i].x +
+               R.at<double>(0, 1) * pts_3d[i].y +
+               R.at<double>(0, 2) * pts_3d[i].z + tvec.at<double>(0);
+    double Y = R.at<double>(1, 0) * pts_3d[i].x +
+               R.at<double>(1, 1) * pts_3d[i].y +
+               R.at<double>(1, 2) * pts_3d[i].z + tvec.at<double>(1);
+    double Z = R.at<double>(2, 0) * pts_3d[i].x +
+               R.at<double>(2, 1) * pts_3d[i].y +
+               R.at<double>(2, 2) * pts_3d[i].z + tvec.at<double>(2);
+    double norm = std::sqrt(X * X + Y * Y + Z * Z);
+
+    BOOST_CHECK_CLOSE(double(rays[i].x), X / norm, 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].y), Y / norm, 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].z), Z / norm, 0.5);
+  }
+}
+
+// ============================================================
+// Test 7: Wide-angle points (edge of fisheye)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSWideAngleProjection) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // Points at various angles from optical axis
+  std::vector<cv::Point3f> pts_3d;
+  pts_3d.emplace_back(0.0f, 0.0f, 1.0f);   // on-axis
+  pts_3d.emplace_back(0.5f, 0.0f, 1.0f);   // ~26.5 deg off-axis
+  pts_3d.emplace_back(0.0f, 0.5f, 1.0f);   // ~26.5 deg off-axis
+  pts_3d.emplace_back(1.0f, 0.0f, 1.0f);   // ~45 deg off-axis
+  pts_3d.emplace_back(-1.0f, -1.0f, 1.0f); // ~54.7 deg off-axis
+
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  // On-axis point should be at principal point
+  BOOST_CHECK_CLOSE(pts_2d[0].x, DS_CX, 0.01);
+  BOOST_CHECK_CLOSE(pts_2d[0].y, DS_CY, 0.01);
+
+  // Points right of center should have u > cx
+  BOOST_CHECK_GT(pts_2d[1].x, DS_CX);
+  // Points below center should have v > cy
+  BOOST_CHECK_GT(pts_2d[2].y, DS_CY);
+
+  // Symmetric points should be equidistant from center
+  float dist_right = pts_2d[1].x - static_cast<float>(DS_CX);
+  float dist_down = pts_2d[2].y - static_cast<float>(DS_CY);
+  // fx ~= fy, so horizontal and vertical offsets should be similar
+  BOOST_CHECK_CLOSE(dist_right, dist_down, 1.0);
+
+  // Round-trip all points
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    float norm =
+        std::sqrt(pts_3d[i].x * pts_3d[i].x + pts_3d[i].y * pts_3d[i].y +
+                  pts_3d[i].z * pts_3d[i].z);
+    BOOST_CHECK_CLOSE(double(rays[i].x), double(pts_3d[i].x / norm), 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].y), double(pts_3d[i].y / norm), 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].z), double(pts_3d[i].z / norm), 0.5);
+  }
+}
+
+// ============================================================
+// Test 8: DS model vs Brown model on same point (sanity check)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSvsBrownDifferentProjection) {
+  auto ds_cam = makeDSCamera();
+  cv::Mat ds_cam_mat, ds_dist;
+  getCameraMatAndDist(ds_cam, ds_cam_mat, ds_dist);
+
+  // Brown camera with same focal length but no distortion
+  cv::Mat brown_cam_mat =
+      (cv::Mat_<double>(3, 3) << DS_FX, 0, DS_CX, 0, DS_FY, DS_CY, 0, 0, 1);
+  cv::Mat brown_dist = cv::Mat::zeros(1, 5, CV_64F);
+
+  // Off-axis point
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.5f, 0.3f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+
+  std::vector<cv::Point2f> ds_pts, brown_pts;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, ds_cam_mat, ds_dist,
+                                       2, ds_pts);
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, brown_cam_mat,
+                                       brown_dist, 0, brown_pts);
+
+  // DS and Brown should give DIFFERENT results (DS has additional distortion)
+  double diff = std::sqrt(std::pow(ds_pts[0].x - brown_pts[0].x, 2) +
+                          std::pow(ds_pts[0].y - brown_pts[0].y, 2));
+  BOOST_CHECK_GT(diff, 1.0); // Should differ by more than 1 pixel
+}
+
+// ============================================================
+// Test 9: DS distortion model type preserved in Camera
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSDistortionModelType) {
+  McCalib::Camera cam_brown(0, 0);
+  McCalib::Camera cam_kannala(1, 1);
+  McCalib::Camera cam_ds(2, 2);
+
+  BOOST_CHECK_EQUAL(cam_brown.distortion_model_, 0);
+  BOOST_CHECK_EQUAL(cam_kannala.distortion_model_, 1);
+  BOOST_CHECK_EQUAL(cam_ds.distortion_model_, 2);
+}
+
+// ============================================================
+// Test 10: Batch unprojection produces correct number of rays
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSUnprojectBatchSize) {
+  auto cam = makeDSCamera();
+
+  // Generate a grid of 2D points
+  std::vector<cv::Point2f> pts_2d;
+  for (int r = 0; r < 10; r++) {
+    for (int c = 0; c < 10; c++) {
+      pts_2d.emplace_back(400.0f + c * 100.0f, 200.0f + r * 60.0f);
+    }
+  }
+
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  BOOST_CHECK_EQUAL(rays.size(), pts_2d.size());
+
+  // All rays should be unit vectors
+  for (const auto &ray : rays) {
+    double norm = std::sqrt(ray.x * ray.x + ray.y * ray.y + ray.z * ray.z);
+    BOOST_CHECK_CLOSE(norm, 1.0, 0.1);
+  }
+}
+
+// ============================================================
+// Test 11: Extreme DS parameters (boundary values)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSExtremParameterBounds) {
+  // Camera with xi=0, alpha=0 should behave like standard perspective
+  auto cam = std::make_shared<McCalib::Camera>(0, 2);
+  cam->im_cols_ = 1920;
+  cam->im_rows_ = 1080;
+  cam->intrinsics_[0] = 500.0;
+  cam->intrinsics_[1] = 500.0;
+  cam->intrinsics_[2] = 960.0;
+  cam->intrinsics_[3] = 540.0;
+  cam->intrinsics_[4] = 0.0; // xi = 0
+  cam->intrinsics_[5] = 0.0; // alpha = 0
+
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // With xi=0, alpha=0, DS reduces to standard pinhole:
+  // d1 = ||P||, z1 = Z + 0 = Z, d2 = ||P||, den = 0 + 1*Z = Z
+  // u = fx * X/Z + cx (standard pinhole)
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.1f, -0.05f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+
+  std::vector<cv::Point2f> ds_pts;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       ds_pts);
+
+  // Expected pinhole projection: u = fx*X/Z + cx, v = fy*Y/Z + cy
+  double expected_u = 500.0 * 0.1 / 1.0 + 960.0;     // 1010
+  double expected_v = 500.0 * (-0.05) / 1.0 + 540.0; // 515
+
+  BOOST_CHECK_CLOSE(ds_pts[0].x, expected_u, 0.01);
+  BOOST_CHECK_CLOSE(ds_pts[0].y, expected_v, 0.01);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Implement Double Sphere (DS) projection in `projectPointsWithDistortion()` for `distortion_type == 2`
- Add `Camera::dsUnproject()` for closed-form DS unprojection (Usenko et al. 2018)
- Add DS branches in `setDistortionVector()` and `getDistortionVectorVector()` to store/retrieve xi and alpha in `intrinsics_[4]` and `intrinsics_[5]`
- Zero-initialize `intrinsics_` array to prevent garbage in unused slots

## Motivation

MC-Calib currently supports Brown (perspective) and Kannala-Brandt (fisheye) camera models. The Double Sphere model provides a compact 6-parameter (fx, fy, cx, cy, xi, alpha) alternative for wide-angle and fisheye cameras with a closed-form inverse, making it efficient for both projection and unprojection.

This is PR 1/4 in a series adding full DS support to MC-Calib.

## Changes

| File | Change |
|------|--------|
| `McCalib/include/Camera.hpp` | Zero-init `intrinsics_{}`, declare `dsUnproject()` |
| `McCalib/src/Camera.cpp` | DS branches in `setDistortionVector()`, `getDistortionVectorVector()`, new `dsUnproject()` method |
| `McCalib/src/geometrytools.cpp` | DS branch in `projectPointsWithDistortion()` |

## Test Plan

- [ ] Existing Boost tests pass (no regressions, DS code is additive via `if (distortion_model_ == 2)` branches)
- [ ] DS projection matches reference Python implementation
- [ ] DS unprojection round-trip error < 1e-6 pixels