### PR TITLE
Add Double Sphere Ceres optimization and parameter bounds

### DIFF
--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -43,7 +43,7 @@ public:
   // intrinsics
   // fx,fy,u0,v0,r1,r2,t1,t2,r3 (perspective)
   // fx,fy,u0,v0,k1,k2,k3,k4 (Kannala)
-  std::array<double, 9> intrinsics_;
+  std::array<double, 9> intrinsics_{};
 
   int cam_idx_ = 0; // camera index
   int distortion_model_ = 0;
@@ -65,6 +65,8 @@ public:
   void getIntrinsics(cv::Mat &K, cv::Mat &distortion_vector);
   void setIntrinsics(const cv::Mat &K, const cv::Mat &distortion_vector);
   bool checkBorderToleranceFisheye(const std::shared_ptr<BoardObs> board_obs);
+  void dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                   std::vector<cv::Point3f> &rays) const;
 };
 
 } // namespace McCalib

--- a/McCalib/include/OptimizationCeres.h
+++ b/McCalib/include/OptimizationCeres.h
@@ -60,6 +60,42 @@ struct ReprojectionError {
       residuals[1] = vp - T(v);
     }
 
+    if (distortion_type == 2) // Double Sphere
+    {
+      // Recover unnormalized 3D coordinates
+      T px = p[0] * p[2];
+      T py = p[1] * p[2];
+      T pz = p[2];
+
+      const T fx = Intrinsics[0];
+      const T fy = Intrinsics[1];
+      const T cx = Intrinsics[2];
+      const T cy = Intrinsics[3];
+      const T xi = Intrinsics[4];
+      const T alpha = Intrinsics[5];
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+
+      // Basalt validity check
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
+    }
+
     if (distortion_type == 1) // fisheye
     {
       // apply distorsion
@@ -179,6 +215,39 @@ struct ReprojectionError_3DObjRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = p[0] * p[2];
+      T py = p[1] * p[2];
+      T pz = p[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -309,6 +378,39 @@ struct ReprojectionError_CameraGroupRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -450,6 +552,39 @@ struct ReprojectionError_CameraGroupAndObjectRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -601,6 +736,36 @@ struct ReprojectionError_CameraGroupAndObjectRefAndIntrinsics {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere
+    {
+      // For DS: cam_int[4]=xi, cam_int[5]=alpha
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T xi = cam_int[4];
+      T alpha = cam_int[5];
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = focal_x * px / den + u0 - T(u);
+      residuals[1] = focal_y * py / den + v0 - T(v);
     }
 
     if (distortion_type == 1) // fisheye

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -66,6 +66,10 @@ void Camera::setDistortionVector(const cv::Mat &distortion_vector) {
       intrinsics_[intrinIdx] = distortion_vector.at<double>(distIdx);
     }
   }
+  if (distortion_model_ == 2) {                       // Double Sphere
+    intrinsics_[4] = distortion_vector.at<double>(0); // xi
+    intrinsics_[5] = distortion_vector.at<double>(1); // alpha
+  }
 }
 
 /**
@@ -91,6 +95,13 @@ cv::Mat Camera::getDistortionVectorVector() const {
       std::size_t distIdx = intrinIdx - 4u;
       distortion_vector.at<double>(distIdx) = intrinsics_[intrinIdx];
     }
+    return distortion_vector;
+  }
+
+  else if (distortion_model_ == 2) { // Double Sphere
+    cv::Mat distortion_vector = cv::Mat(1, 2, CV_64F, cv::Scalar(0));
+    distortion_vector.at<double>(0) = intrinsics_[4]; // xi
+    distortion_vector.at<double>(1) = intrinsics_[5]; // alpha
     return distortion_vector;
   }
 
@@ -302,6 +313,58 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
   LOG_INFO << "Parameters after optimization :: " << this->getCameraMat();
   LOG_INFO << "distortion vector after optimization :: "
            << getDistortionVectorVector();
+}
+
+/**
+ * @brief Unproject 2D points to 3D rays using Double Sphere model
+ *
+ * @param pts_2d input 2D pixel coordinates
+ * @param rays output 3D ray directions (unit vectors)
+ */
+void Camera::dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                         std::vector<cv::Point3f> &rays) const {
+  rays.clear();
+  rays.reserve(pts_2d.size());
+
+  const double fx = intrinsics_[0];
+  const double fy = intrinsics_[1];
+  const double cx = intrinsics_[2];
+  const double cy = intrinsics_[3];
+  const double xi = intrinsics_[4];
+  const double alpha = intrinsics_[5];
+
+  for (const auto &pt : pts_2d) {
+    double mx = (pt.x - cx) / fx;
+    double my = (pt.y - cy) / fy;
+    double r2 = mx * mx + my * my;
+
+    // Validity check
+    double s = 1.0 - (2.0 * alpha - 1.0) * r2;
+    if (s < 0)
+      s = 0; // Clamp
+
+    double mz =
+        (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
+
+    double mz2 = mz * mz;
+    double denom = mz2 + r2;
+    if (denom < 1e-10)
+      denom = 1e-10;
+    double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+
+    double ray_x = k * mx;
+    double ray_y = k * my;
+    double ray_z = k * mz - xi;
+
+    // Normalize to unit vector
+    double norm = std::sqrt(ray_x * ray_x + ray_y * ray_y + ray_z * ray_z);
+    if (norm > 1e-10) {
+      rays.emplace_back(float(ray_x / norm), float(ray_y / norm),
+                        float(ray_z / norm));
+    } else {
+      rays.emplace_back(0.f, 0.f, 1.f);
+    }
+  }
 }
 
 } // namespace McCalib

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -176,6 +176,109 @@ void Camera::initializeCalibration() {
   LOG_INFO << "NB of frames where this camera saw a board :: "
            << frames_.size();
 
+  if (distortion_model_ == 2) { // Double Sphere Initialization
+    LOG_INFO << "Initializing Double Sphere Camera...";
+
+    // 1. Initialize Intrinsics (Heuristic)
+    double max_dim = std::max(im_cols_, im_rows_);
+    intrinsics_[0] = 0.8 * max_dim;  // fx
+    intrinsics_[1] = 0.8 * max_dim;  // fy
+    intrinsics_[2] = im_cols_ / 2.0; // cx
+    intrinsics_[3] = im_rows_ / 2.0; // cy
+    intrinsics_[4] = 0.5;            // xi
+    intrinsics_[5] = 0.5;            // alpha
+
+    // 2. Initialize Extrinsics (PnP on unprojected rays)
+    for (auto &it : board_observations_) {
+      std::shared_ptr<BoardObs> board_obs = it.second.lock();
+      if (!board_obs)
+        continue;
+
+      std::shared_ptr<Board> board_3d = board_obs->board_3d_.lock();
+      if (!board_3d)
+        continue;
+
+      // Get 3D object points
+      std::vector<cv::Point3f> obj_pts;
+      for (int idx : board_obs->charuco_id_) {
+        obj_pts.push_back(board_3d->pts_3d_[idx]);
+      }
+
+      // Unproject 2D points to 3D rays
+      std::vector<cv::Point3f> rays;
+      dsUnproject(board_obs->pts_2d_, rays);
+
+      // Convert rays to normalized 2D points (x/z, y/z) for PnP
+      std::vector<cv::Point2f> norm_pts;
+      for (const auto &ray : rays) {
+        if (ray.z > 1e-6f)
+          norm_pts.emplace_back(ray.x / ray.z, ray.y / ray.z);
+        else
+          norm_pts.emplace_back(0, 0);
+      }
+
+      // Solve PnP
+      cv::Mat rvec, tvec;
+      if (norm_pts.size() >= 4) {
+        cv::solvePnP(obj_pts, norm_pts, cv::Mat::eye(3, 3, CV_64F), cv::Mat(),
+                     rvec, tvec);
+        board_obs->pose_[0] = rvec.at<double>(0);
+        board_obs->pose_[1] = rvec.at<double>(1);
+        board_obs->pose_[2] = rvec.at<double>(2);
+        board_obs->pose_[3] = tvec.at<double>(0);
+        board_obs->pose_[4] = tvec.at<double>(1);
+        board_obs->pose_[5] = tvec.at<double>(2);
+        board_obs->valid_ = true;
+      }
+    }
+
+    // 3. Optimization Step: Refine intrinsics and extrinsics jointly
+    LOG_INFO << "Refining Single Camera Calibration (Initialization)...";
+    refineIntrinsicCalibration(100);
+
+    // 4. PnP Refinement: Re-estimate poses with optimized intrinsics
+    LOG_INFO << "Refining Poses with Optimized Intrinsics...";
+    for (auto &it : board_observations_) {
+      std::shared_ptr<BoardObs> board_obs = it.second.lock();
+      if (!board_obs || !board_obs->valid_)
+        continue;
+
+      std::shared_ptr<Board> board_3d = board_obs->board_3d_.lock();
+      if (!board_3d)
+        continue;
+
+      std::vector<cv::Point3f> obj_pts;
+      for (int idx : board_obs->charuco_id_) {
+        obj_pts.push_back(board_3d->pts_3d_[idx]);
+      }
+
+      std::vector<cv::Point3f> rays;
+      dsUnproject(board_obs->pts_2d_, rays);
+
+      std::vector<cv::Point2f> norm_pts;
+      for (const auto &ray : rays) {
+        if (ray.z > 1e-6f)
+          norm_pts.emplace_back(ray.x / ray.z, ray.y / ray.z);
+        else
+          norm_pts.emplace_back(0, 0);
+      }
+
+      cv::Mat rvec, tvec;
+      if (norm_pts.size() >= 4) {
+        cv::solvePnP(obj_pts, norm_pts, cv::Mat::eye(3, 3, CV_64F), cv::Mat(),
+                     rvec, tvec);
+        board_obs->pose_[0] = rvec.at<double>(0);
+        board_obs->pose_[1] = rvec.at<double>(1);
+        board_obs->pose_[2] = rvec.at<double>(2);
+        board_obs->pose_[3] = tvec.at<double>(0);
+        board_obs->pose_[4] = tvec.at<double>(1);
+        board_obs->pose_[5] = tvec.at<double>(2);
+      }
+    }
+
+    return; // Done with DS initialization
+  }
+
   // Subsample the total number of images (because the OpenCV function is
   // significantly too slow...)
   std::vector<int> indbv(board_observations_.size());

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -406,6 +406,14 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
       }
     }
   }
+  // Set parameter bounds for Double Sphere model
+  if (distortion_model_ == 2) {
+    problem.SetParameterLowerBound(intrinsics_.data(), 4, -1.0); // xi
+    problem.SetParameterUpperBound(intrinsics_.data(), 4, 1.0);
+    problem.SetParameterLowerBound(intrinsics_.data(), 5, 0.0); // alpha
+    problem.SetParameterUpperBound(intrinsics_.data(), 5, 1.0);
+  }
+
   // Run the optimization
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::SPARSE_SCHUR;

--- a/McCalib/src/CameraGroup.cpp
+++ b/McCalib/src/CameraGroup.cpp
@@ -568,6 +568,18 @@ void CameraGroup::refineCameraGroupAndObjectsAndIntrinsics(
       }
     }
   }
+
+  // Set parameter bounds for Double Sphere cameras
+  for (const auto &it_cam : cameras_) {
+    auto cam = it_cam.second.lock();
+    if (cam && cam->distortion_model_ == 2) {
+      problem.SetParameterLowerBound(cam->intrinsics_.data(), 4, -1.0);
+      problem.SetParameterUpperBound(cam->intrinsics_.data(), 4, 1.0);
+      problem.SetParameterLowerBound(cam->intrinsics_.data(), 5, 0.0);
+      problem.SetParameterUpperBound(cam->intrinsics_.data(), 5, 1.0);
+    }
+  }
+
   // Run the optimization
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::SPARSE_SCHUR;

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -747,6 +747,57 @@ cv::Mat ransacP3PDistortion(const std::vector<cv::Point3f> &scene_points,
                         refine);
   }
 
+  // P3P for Double Sphere
+  if (distortion_type == 2) {
+    // Unproject DS points to rays, then project to virtual pinhole
+    std::vector<cv::Point2f> imagePointsUndis;
+    imagePointsUndis.reserve(image_points.size());
+
+    double fx = intrinsic.at<double>(0, 0);
+    double fy = intrinsic.at<double>(1, 1);
+    double cx = intrinsic.at<double>(0, 2);
+    double cy = intrinsic.at<double>(1, 2);
+    double xi = distortion_vector.at<double>(0);
+    double alpha = distortion_vector.at<double>(1);
+
+    for (const auto &pt : image_points) {
+      double mx = (pt.x - cx) / fx;
+      double my = (pt.y - cy) / fy;
+      double r2 = mx * mx + my * my;
+
+      // DS Unprojection
+      double s = 1.0 - (2.0 * alpha - 1.0) * r2;
+      if (s < 0)
+        s = 0;
+
+      double mz =
+          (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
+
+      double mz2 = mz * mz;
+      double denom = mz2 + r2;
+      if (denom < 1e-10)
+        denom = 1e-10;
+      double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+
+      double ray_x = k * mx;
+      double ray_y = k * my;
+      double ray_z = k * mz - xi;
+
+      // Project to virtual pinhole (using K)
+      double u_pin = fx * (ray_x / ray_z) + cx;
+      double v_pin = fy * (ray_y / ray_z) + cy;
+
+      imagePointsUndis.emplace_back(float(u_pin), float(v_pin));
+    }
+
+    // Run P3P with zero distortion
+    const cv::Mat zero_distortion_vector =
+        (cv::Mat_<double>(1, 5) << 0, 0, 0, 0, 0);
+    Inliers = ransacP3P(scene_points, imagePointsUndis, intrinsic,
+                        zero_distortion_vector, best_R, best_T, thresh, it, p,
+                        refine);
+  }
+
   return Inliers;
 }
 

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -768,6 +768,46 @@ void projectPointsWithDistortion(const std::vector<cv::Point3f> &object_pts,
     cv::fisheye::projectPoints(object_pts, repro_pts, rot, trans, camera_matrix,
                                distortion_vector, 0.0);
   }
+  if (distortion_type == 2) // Double Sphere
+  {
+    cv::Mat R;
+    cv::Rodrigues(rot, R);
+    double fx = camera_matrix.at<double>(0, 0);
+    double fy = camera_matrix.at<double>(1, 1);
+    double cx = camera_matrix.at<double>(0, 2);
+    double cy = camera_matrix.at<double>(1, 2);
+    double xi = distortion_vector.at<double>(0);
+    double alpha = distortion_vector.at<double>(1);
+
+    double tx = trans.at<double>(0);
+    double ty = trans.at<double>(1);
+    double tz = trans.at<double>(2);
+
+    repro_pts.reserve(object_pts.size());
+    for (const auto &pt : object_pts) {
+      // Transform 3D point to camera frame
+      double X = R.at<double>(0, 0) * pt.x + R.at<double>(0, 1) * pt.y +
+                 R.at<double>(0, 2) * pt.z + tx;
+      double Y = R.at<double>(1, 0) * pt.x + R.at<double>(1, 1) * pt.y +
+                 R.at<double>(1, 2) * pt.z + ty;
+      double Z = R.at<double>(2, 0) * pt.x + R.at<double>(2, 1) * pt.y +
+                 R.at<double>(2, 2) * pt.z + tz;
+
+      // DS Projection
+      double d1 = std::sqrt(X * X + Y * Y + Z * Z);
+      double z1 = Z + xi * d1;
+      double d2 = std::sqrt(X * X + Y * Y + z1 * z1);
+      double den = alpha * d2 + (1.0 - alpha) * z1;
+
+      if (std::abs(den) > 1e-8) {
+        double u = fx * X / den + cx;
+        double v = fy * Y / den + cy;
+        repro_pts.emplace_back(float(u), float(v));
+      } else {
+        repro_pts.emplace_back(0.f, 0.f);
+      }
+    }
+  }
 }
 
 cv::Mat convertRotationMatrixToQuaternion(const cv::Mat &R) {


### PR DESCRIPTION
## Summary

- Add DS projection blocks to all 5 Ceres cost function structs in `OptimizationCeres.h`
- Add xi bounds [-1, 1] and alpha bounds [0, 1] in `Camera::refineIntrinsicCalibration()` and `CameraGroup::refineCameraGroupAndObjectsAndIntrinsics()`
- All DS blocks include the Basalt validity check (Usenko et al. 2018) to handle points behind the camera

## Motivation

With projection/unprojection (#106) and PnP/initialization (#107) in place, this PR completes the optimization pipeline. DS parameters xi and alpha have physical bounds that must be enforced during Ceres optimization to prevent divergence.

This is PR 3/4 in a series adding full DS support. Depends on #107.

## Changes

| File | Change |
|------|--------|
| `McCalib/include/OptimizationCeres.h` | DS blocks in `ReprojectionError`, `ReprojectionError_3DObjRef`, `ReprojectionError_CameraGroupRef`, `ReprojectionError_CameraGroupAndObjectRef`, `ReprojectionError_CameraGroupAndObjectRefAndIntrinsics` |
| `McCalib/src/Camera.cpp` | DS parameter bounds in `refineIntrinsicCalibration()` |
| `McCalib/src/CameraGroup.cpp` | DS parameter bounds in `refineCameraGroupAndObjectsAndIntrinsics()` |

## Test Plan

- [ ] Existing Boost tests pass
- [ ] End-to-end heterogeneous calibration (Brown + DS + Brown) converges with < 2px reprojection error
- [ ] DS parameters xi and alpha remain within bounds after optimization