### PR TITLE
Add Double Sphere unit tests and heterogeneous config

### DIFF
--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -43,7 +43,7 @@ public:
   // intrinsics
   // fx,fy,u0,v0,r1,r2,t1,t2,r3 (perspective)
   // fx,fy,u0,v0,k1,k2,k3,k4 (Kannala)
-  std::array<double, 9> intrinsics_;
+  std::array<double, 9> intrinsics_{};
 
   int cam_idx_ = 0; // camera index
   int distortion_model_ = 0;
@@ -65,6 +65,8 @@ public:
   void getIntrinsics(cv::Mat &K, cv::Mat &distortion_vector);
   void setIntrinsics(const cv::Mat &K, const cv::Mat &distortion_vector);
   bool checkBorderToleranceFisheye(const std::shared_ptr<BoardObs> board_obs);
+  void dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                   std::vector<cv::Point3f> &rays) const;
 };
 
 } // namespace McCalib

--- a/McCalib/include/OptimizationCeres.h
+++ b/McCalib/include/OptimizationCeres.h
@@ -60,6 +60,42 @@ struct ReprojectionError {
       residuals[1] = vp - T(v);
     }
 
+    if (distortion_type == 2) // Double Sphere
+    {
+      // Recover unnormalized 3D coordinates
+      T px = p[0] * p[2];
+      T py = p[1] * p[2];
+      T pz = p[2];
+
+      const T fx = Intrinsics[0];
+      const T fy = Intrinsics[1];
+      const T cx = Intrinsics[2];
+      const T cy = Intrinsics[3];
+      const T xi = Intrinsics[4];
+      const T alpha = Intrinsics[5];
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+
+      // Basalt validity check
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
+    }
+
     if (distortion_type == 1) // fisheye
     {
       // apply distorsion
@@ -179,6 +215,39 @@ struct ReprojectionError_3DObjRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = p[0] * p[2];
+      T py = p[1] * p[2];
+      T pz = p[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -309,6 +378,39 @@ struct ReprojectionError_CameraGroupRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -450,6 +552,39 @@ struct ReprojectionError_CameraGroupAndObjectRef {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere (k1=xi, k2=alpha)
+    {
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T fx = T(focal_x);
+      T fy = T(focal_y);
+      T cx = T(u0);
+      T cy = T(v0);
+      T xi = T(k1);
+      T alpha = T(k2);
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = fx * px / den + cx - T(u);
+      residuals[1] = fy * py / den + cy - T(v);
     }
 
     if (distortion_type == 1) // fisheye
@@ -601,6 +736,36 @@ struct ReprojectionError_CameraGroupAndObjectRefAndIntrinsics {
       // position.
       residuals[0] = up - T(u);
       residuals[1] = vp - T(v);
+    }
+
+    if (distortion_type == 2) // Double Sphere
+    {
+      // For DS: cam_int[4]=xi, cam_int[5]=alpha
+      T px = pobj[0] * pobj[2];
+      T py = pobj[1] * pobj[2];
+      T pz = pobj[2];
+
+      T xi = cam_int[4];
+      T alpha = cam_int[5];
+
+      T d1 = sqrt(px * px + py * py + pz * pz);
+      T w1 = (alpha > T(0.5)) ? (T(1.0) - alpha) / alpha
+                              : alpha / (T(1.0) - alpha);
+      T w2 = (w1 + xi) / sqrt(T(2.0) * w1 * xi + xi * xi + T(1.0));
+      if (pz <= -w2 * d1) {
+        residuals[0] = T(10000.0);
+        residuals[1] = T(10000.0);
+        return true;
+      }
+
+      T z1 = pz + xi * d1;
+      T d2 = sqrt(px * px + py * py + z1 * z1);
+      T den = alpha * d2 + (T(1.0) - alpha) * z1;
+      if (den < T(1e-8))
+        den = T(1e-8);
+
+      residuals[0] = focal_x * px / den + u0 - T(u);
+      residuals[1] = focal_y * py / den + v0 - T(v);
     }
 
     if (distortion_type == 1) // fisheye

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -66,6 +66,10 @@ void Camera::setDistortionVector(const cv::Mat &distortion_vector) {
       intrinsics_[intrinIdx] = distortion_vector.at<double>(distIdx);
     }
   }
+  if (distortion_model_ == 2) {                       // Double Sphere
+    intrinsics_[4] = distortion_vector.at<double>(0); // xi
+    intrinsics_[5] = distortion_vector.at<double>(1); // alpha
+  }
 }
 
 /**
@@ -91,6 +95,13 @@ cv::Mat Camera::getDistortionVectorVector() const {
       std::size_t distIdx = intrinIdx - 4u;
       distortion_vector.at<double>(distIdx) = intrinsics_[intrinIdx];
     }
+    return distortion_vector;
+  }
+
+  else if (distortion_model_ == 2) { // Double Sphere
+    cv::Mat distortion_vector = cv::Mat(1, 2, CV_64F, cv::Scalar(0));
+    distortion_vector.at<double>(0) = intrinsics_[4]; // xi
+    distortion_vector.at<double>(1) = intrinsics_[5]; // alpha
     return distortion_vector;
   }
 
@@ -302,6 +313,58 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
   LOG_INFO << "Parameters after optimization :: " << this->getCameraMat();
   LOG_INFO << "distortion vector after optimization :: "
            << getDistortionVectorVector();
+}
+
+/**
+ * @brief Unproject 2D points to 3D rays using Double Sphere model
+ *
+ * @param pts_2d input 2D pixel coordinates
+ * @param rays output 3D ray directions (unit vectors)
+ */
+void Camera::dsUnproject(const std::vector<cv::Point2f> &pts_2d,
+                         std::vector<cv::Point3f> &rays) const {
+  rays.clear();
+  rays.reserve(pts_2d.size());
+
+  const double fx = intrinsics_[0];
+  const double fy = intrinsics_[1];
+  const double cx = intrinsics_[2];
+  const double cy = intrinsics_[3];
+  const double xi = intrinsics_[4];
+  const double alpha = intrinsics_[5];
+
+  for (const auto &pt : pts_2d) {
+    double mx = (pt.x - cx) / fx;
+    double my = (pt.y - cy) / fy;
+    double r2 = mx * mx + my * my;
+
+    // Validity check
+    double s = 1.0 - (2.0 * alpha - 1.0) * r2;
+    if (s < 0)
+      s = 0; // Clamp
+
+    double mz =
+        (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
+
+    double mz2 = mz * mz;
+    double denom = mz2 + r2;
+    if (denom < 1e-10)
+      denom = 1e-10;
+    double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+
+    double ray_x = k * mx;
+    double ray_y = k * my;
+    double ray_z = k * mz - xi;
+
+    // Normalize to unit vector
+    double norm = std::sqrt(ray_x * ray_x + ray_y * ray_y + ray_z * ray_z);
+    if (norm > 1e-10) {
+      rays.emplace_back(float(ray_x / norm), float(ray_y / norm),
+                        float(ray_z / norm));
+    } else {
+      rays.emplace_back(0.f, 0.f, 1.f);
+    }
+  }
 }
 
 } // namespace McCalib

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -176,6 +176,109 @@ void Camera::initializeCalibration() {
   LOG_INFO << "NB of frames where this camera saw a board :: "
            << frames_.size();
 
+  if (distortion_model_ == 2) { // Double Sphere Initialization
+    LOG_INFO << "Initializing Double Sphere Camera...";
+
+    // 1. Initialize Intrinsics (Heuristic)
+    double max_dim = std::max(im_cols_, im_rows_);
+    intrinsics_[0] = 0.8 * max_dim;  // fx
+    intrinsics_[1] = 0.8 * max_dim;  // fy
+    intrinsics_[2] = im_cols_ / 2.0; // cx
+    intrinsics_[3] = im_rows_ / 2.0; // cy
+    intrinsics_[4] = 0.5;            // xi
+    intrinsics_[5] = 0.5;            // alpha
+
+    // 2. Initialize Extrinsics (PnP on unprojected rays)
+    for (auto &it : board_observations_) {
+      std::shared_ptr<BoardObs> board_obs = it.second.lock();
+      if (!board_obs)
+        continue;
+
+      std::shared_ptr<Board> board_3d = board_obs->board_3d_.lock();
+      if (!board_3d)
+        continue;
+
+      // Get 3D object points
+      std::vector<cv::Point3f> obj_pts;
+      for (int idx : board_obs->charuco_id_) {
+        obj_pts.push_back(board_3d->pts_3d_[idx]);
+      }
+
+      // Unproject 2D points to 3D rays
+      std::vector<cv::Point3f> rays;
+      dsUnproject(board_obs->pts_2d_, rays);
+
+      // Convert rays to normalized 2D points (x/z, y/z) for PnP
+      std::vector<cv::Point2f> norm_pts;
+      for (const auto &ray : rays) {
+        if (ray.z > 1e-6f)
+          norm_pts.emplace_back(ray.x / ray.z, ray.y / ray.z);
+        else
+          norm_pts.emplace_back(0, 0);
+      }
+
+      // Solve PnP
+      cv::Mat rvec, tvec;
+      if (norm_pts.size() >= 4) {
+        cv::solvePnP(obj_pts, norm_pts, cv::Mat::eye(3, 3, CV_64F), cv::Mat(),
+                     rvec, tvec);
+        board_obs->pose_[0] = rvec.at<double>(0);
+        board_obs->pose_[1] = rvec.at<double>(1);
+        board_obs->pose_[2] = rvec.at<double>(2);
+        board_obs->pose_[3] = tvec.at<double>(0);
+        board_obs->pose_[4] = tvec.at<double>(1);
+        board_obs->pose_[5] = tvec.at<double>(2);
+        board_obs->valid_ = true;
+      }
+    }
+
+    // 3. Optimization Step: Refine intrinsics and extrinsics jointly
+    LOG_INFO << "Refining Single Camera Calibration (Initialization)...";
+    refineIntrinsicCalibration(100);
+
+    // 4. PnP Refinement: Re-estimate poses with optimized intrinsics
+    LOG_INFO << "Refining Poses with Optimized Intrinsics...";
+    for (auto &it : board_observations_) {
+      std::shared_ptr<BoardObs> board_obs = it.second.lock();
+      if (!board_obs || !board_obs->valid_)
+        continue;
+
+      std::shared_ptr<Board> board_3d = board_obs->board_3d_.lock();
+      if (!board_3d)
+        continue;
+
+      std::vector<cv::Point3f> obj_pts;
+      for (int idx : board_obs->charuco_id_) {
+        obj_pts.push_back(board_3d->pts_3d_[idx]);
+      }
+
+      std::vector<cv::Point3f> rays;
+      dsUnproject(board_obs->pts_2d_, rays);
+
+      std::vector<cv::Point2f> norm_pts;
+      for (const auto &ray : rays) {
+        if (ray.z > 1e-6f)
+          norm_pts.emplace_back(ray.x / ray.z, ray.y / ray.z);
+        else
+          norm_pts.emplace_back(0, 0);
+      }
+
+      cv::Mat rvec, tvec;
+      if (norm_pts.size() >= 4) {
+        cv::solvePnP(obj_pts, norm_pts, cv::Mat::eye(3, 3, CV_64F), cv::Mat(),
+                     rvec, tvec);
+        board_obs->pose_[0] = rvec.at<double>(0);
+        board_obs->pose_[1] = rvec.at<double>(1);
+        board_obs->pose_[2] = rvec.at<double>(2);
+        board_obs->pose_[3] = tvec.at<double>(0);
+        board_obs->pose_[4] = tvec.at<double>(1);
+        board_obs->pose_[5] = tvec.at<double>(2);
+      }
+    }
+
+    return; // Done with DS initialization
+  }
+
   // Subsample the total number of images (because the OpenCV function is
   // significantly too slow...)
   std::vector<int> indbv(board_observations_.size());

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -406,6 +406,14 @@ void Camera::refineIntrinsicCalibration(const int nb_iterations) {
       }
     }
   }
+  // Set parameter bounds for Double Sphere model
+  if (distortion_model_ == 2) {
+    problem.SetParameterLowerBound(intrinsics_.data(), 4, -1.0); // xi
+    problem.SetParameterUpperBound(intrinsics_.data(), 4, 1.0);
+    problem.SetParameterLowerBound(intrinsics_.data(), 5, 0.0); // alpha
+    problem.SetParameterUpperBound(intrinsics_.data(), 5, 1.0);
+  }
+
   // Run the optimization
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::SPARSE_SCHUR;

--- a/McCalib/src/CameraGroup.cpp
+++ b/McCalib/src/CameraGroup.cpp
@@ -568,6 +568,18 @@ void CameraGroup::refineCameraGroupAndObjectsAndIntrinsics(
       }
     }
   }
+
+  // Set parameter bounds for Double Sphere cameras
+  for (const auto &it_cam : cameras_) {
+    auto cam = it_cam.second.lock();
+    if (cam && cam->distortion_model_ == 2) {
+      problem.SetParameterLowerBound(cam->intrinsics_.data(), 4, -1.0);
+      problem.SetParameterUpperBound(cam->intrinsics_.data(), 4, 1.0);
+      problem.SetParameterLowerBound(cam->intrinsics_.data(), 5, 0.0);
+      problem.SetParameterUpperBound(cam->intrinsics_.data(), 5, 1.0);
+    }
+  }
+
   // Run the optimization
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::SPARSE_SCHUR;

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -747,6 +747,57 @@ cv::Mat ransacP3PDistortion(const std::vector<cv::Point3f> &scene_points,
                         refine);
   }
 
+  // P3P for Double Sphere
+  if (distortion_type == 2) {
+    // Unproject DS points to rays, then project to virtual pinhole
+    std::vector<cv::Point2f> imagePointsUndis;
+    imagePointsUndis.reserve(image_points.size());
+
+    double fx = intrinsic.at<double>(0, 0);
+    double fy = intrinsic.at<double>(1, 1);
+    double cx = intrinsic.at<double>(0, 2);
+    double cy = intrinsic.at<double>(1, 2);
+    double xi = distortion_vector.at<double>(0);
+    double alpha = distortion_vector.at<double>(1);
+
+    for (const auto &pt : image_points) {
+      double mx = (pt.x - cx) / fx;
+      double my = (pt.y - cy) / fy;
+      double r2 = mx * mx + my * my;
+
+      // DS Unprojection
+      double s = 1.0 - (2.0 * alpha - 1.0) * r2;
+      if (s < 0)
+        s = 0;
+
+      double mz =
+          (1.0 - alpha * alpha * r2) / (alpha * std::sqrt(s) + (1.0 - alpha));
+
+      double mz2 = mz * mz;
+      double denom = mz2 + r2;
+      if (denom < 1e-10)
+        denom = 1e-10;
+      double k = (mz * xi + std::sqrt(mz2 + (1.0 - xi * xi) * r2)) / denom;
+
+      double ray_x = k * mx;
+      double ray_y = k * my;
+      double ray_z = k * mz - xi;
+
+      // Project to virtual pinhole (using K)
+      double u_pin = fx * (ray_x / ray_z) + cx;
+      double v_pin = fy * (ray_y / ray_z) + cy;
+
+      imagePointsUndis.emplace_back(float(u_pin), float(v_pin));
+    }
+
+    // Run P3P with zero distortion
+    const cv::Mat zero_distortion_vector =
+        (cv::Mat_<double>(1, 5) << 0, 0, 0, 0, 0);
+    Inliers = ransacP3P(scene_points, imagePointsUndis, intrinsic,
+                        zero_distortion_vector, best_R, best_T, thresh, it, p,
+                        refine);
+  }
+
   return Inliers;
 }
 

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -768,6 +768,46 @@ void projectPointsWithDistortion(const std::vector<cv::Point3f> &object_pts,
     cv::fisheye::projectPoints(object_pts, repro_pts, rot, trans, camera_matrix,
                                distortion_vector, 0.0);
   }
+  if (distortion_type == 2) // Double Sphere
+  {
+    cv::Mat R;
+    cv::Rodrigues(rot, R);
+    double fx = camera_matrix.at<double>(0, 0);
+    double fy = camera_matrix.at<double>(1, 1);
+    double cx = camera_matrix.at<double>(0, 2);
+    double cy = camera_matrix.at<double>(1, 2);
+    double xi = distortion_vector.at<double>(0);
+    double alpha = distortion_vector.at<double>(1);
+
+    double tx = trans.at<double>(0);
+    double ty = trans.at<double>(1);
+    double tz = trans.at<double>(2);
+
+    repro_pts.reserve(object_pts.size());
+    for (const auto &pt : object_pts) {
+      // Transform 3D point to camera frame
+      double X = R.at<double>(0, 0) * pt.x + R.at<double>(0, 1) * pt.y +
+                 R.at<double>(0, 2) * pt.z + tx;
+      double Y = R.at<double>(1, 0) * pt.x + R.at<double>(1, 1) * pt.y +
+                 R.at<double>(1, 2) * pt.z + ty;
+      double Z = R.at<double>(2, 0) * pt.x + R.at<double>(2, 1) * pt.y +
+                 R.at<double>(2, 2) * pt.z + tz;
+
+      // DS Projection
+      double d1 = std::sqrt(X * X + Y * Y + Z * Z);
+      double z1 = Z + xi * d1;
+      double d2 = std::sqrt(X * X + Y * Y + z1 * z1);
+      double den = alpha * d2 + (1.0 - alpha) * z1;
+
+      if (std::abs(den) > 1e-8) {
+        double u = fx * X / den + cx;
+        double v = fy * Y / den + cy;
+        repro_pts.emplace_back(float(u), float(v));
+      } else {
+        repro_pts.emplace_back(0.f, 0.f);
+      }
+    }
+  }
 }
 
 cv::Mat convertRotationMatrixToQuaternion(const cv::Mat &R) {

--- a/configs/Real_images/calib_param_extrinsics_heterogeneous.yml
+++ b/configs/Real_images/calib_param_extrinsics_heterogeneous.yml
@@ -1,0 +1,45 @@
+%YAML:1.0
+---
+# Multi-camera calibration config: heterogeneous (Brown + DS + Brown)
+# cam_000: RealSense (Brown/Perspective, model 0)
+# cam_001: Telelian (Double Sphere, model 2)
+# cam_002: RealSense (Brown/Perspective, model 0)
+
+number_camera: 3
+number_board: 2
+boards_index: []
+
+refine_corner: 1
+min_perc_pts: 0.5
+
+number_x_square: 7
+number_y_square: 5
+length_square: 0.04
+length_marker: 0.03
+square_size: 54
+
+number_x_square_per_board: []
+number_y_square_per_board: []
+resolution_x_per_board: []
+resolution_y_per_board: []
+square_size_per_board: []
+
+root_path: "../../extrinsics_mccalib"
+cam_prefix: "cam_"
+keypoints_path: ""
+cam_params_path: "../../extrinsics_mccalib/precalibrated_intrinsics.yml"
+save_path: "../../extrinsics_mccalib/results"
+camera_params_file_name: "camera_params.yml"
+
+save_detection: 1
+save_reprojection: 1
+
+distortion_model: 0
+distortion_per_camera: [0, 2, 0]
+
+he_approach: 0
+fix_intrinsic: 1
+
+quaternion_averaging: 1
+ransac_threshold: 10
+number_iterations: 1000

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package (Boost REQUIRED COMPONENTS unit_test_framework log_setup log REQUIRED)
 
 set(SOURCES
-    main.cpp test_graph.cpp test_calibration.cpp test_geometrytools.cpp simple_unit_tests_example.cpp
+    main.cpp test_graph.cpp test_calibration.cpp test_geometrytools.cpp simple_unit_tests_example.cpp test_double_sphere.cpp
 )
 
 add_executable(boost_tests_run ${SOURCES})

--- a/tests/test_double_sphere.cpp
+++ b/tests/test_double_sphere.cpp
@@ -1,0 +1,351 @@
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <cmath>
+
+#include <Camera.hpp>
+#include <geometrytools.hpp>
+
+BOOST_AUTO_TEST_SUITE(CheckDoubleSphere)
+
+// DS intrinsics: fx, fy, cx, cy, xi, alpha
+static const double DS_FX = 711.574;
+static const double DS_FY = 711.237;
+static const double DS_CX = 960.0;
+static const double DS_CY = 540.0;
+static const double DS_XI = 0.183;
+static const double DS_ALPHA = 0.809;
+
+// Helper: create a Camera with DS intrinsics
+static std::shared_ptr<McCalib::Camera> makeDSCamera() {
+  auto cam = std::make_shared<McCalib::Camera>(0, 2);
+  cam->im_cols_ = 1920;
+  cam->im_rows_ = 1080;
+  cam->intrinsics_[0] = DS_FX;
+  cam->intrinsics_[1] = DS_FY;
+  cam->intrinsics_[2] = DS_CX;
+  cam->intrinsics_[3] = DS_CY;
+  cam->intrinsics_[4] = DS_XI;
+  cam->intrinsics_[5] = DS_ALPHA;
+  return cam;
+}
+
+// Helper: build camera matrix and distortion vector from Camera object
+static void getCameraMatAndDist(const std::shared_ptr<McCalib::Camera> &cam,
+                                cv::Mat &cam_mat, cv::Mat &dist_vec) {
+  cam_mat =
+      (cv::Mat_<double>(3, 3) << cam->intrinsics_[0], 0, cam->intrinsics_[2], 0,
+       cam->intrinsics_[1], cam->intrinsics_[3], 0, 0, 1);
+  dist_vec =
+      (cv::Mat_<double>(1, 2) << cam->intrinsics_[4], cam->intrinsics_[5]);
+}
+
+// ============================================================
+// Test 1: Distortion storage round-trip
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSDistortionStorageRoundTrip) {
+  McCalib::Camera cam(0, 2);
+  cv::Mat dist = (cv::Mat_<double>(1, 2) << 0.183, 0.809);
+  cam.setDistortionVector(dist);
+  cv::Mat dist_out = cam.getDistortionVectorVector();
+  BOOST_CHECK_CLOSE(dist_out.at<double>(0, 0), 0.183, 1e-6);
+  BOOST_CHECK_CLOSE(dist_out.at<double>(0, 1), 0.809, 1e-6);
+}
+
+// ============================================================
+// Test 2: Unused intrinsics slots are zero
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSIntrinsicsZeroInit) {
+  McCalib::Camera cam(0, 2);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[6], 0.0);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[7], 0.0);
+  BOOST_CHECK_EQUAL(cam.intrinsics_[8], 0.0);
+}
+
+// ============================================================
+// Test 3: Projection/Unprojection round-trip for multiple points
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectUnprojectRoundTrip) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  std::vector<cv::Point3f> pts_3d;
+  pts_3d.emplace_back(0.0f, 0.0f, 1.0f);
+  pts_3d.emplace_back(0.1f, -0.05f, 0.8f);
+  pts_3d.emplace_back(-0.2f, 0.15f, 1.2f);
+  pts_3d.emplace_back(0.3f, 0.2f, 0.6f);
+
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    float norm =
+        std::sqrt(pts_3d[i].x * pts_3d[i].x + pts_3d[i].y * pts_3d[i].y +
+                  pts_3d[i].z * pts_3d[i].z);
+    float expected_x = pts_3d[i].x / norm;
+    float expected_y = pts_3d[i].y / norm;
+    float expected_z = pts_3d[i].z / norm;
+
+    BOOST_CHECK_CLOSE(rays[i].x, expected_x, 0.1);
+    BOOST_CHECK_CLOSE(rays[i].y, expected_y, 0.1);
+    BOOST_CHECK_CLOSE(rays[i].z, expected_z, 0.1);
+  }
+}
+
+// ============================================================
+// Test 4: Center point projects to (cx, cy)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectionCenterPoint) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.0f, 0.0f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  BOOST_CHECK_CLOSE(pts_2d[0].x, DS_CX, 0.01);
+  BOOST_CHECK_CLOSE(pts_2d[0].y, DS_CY, 0.01);
+}
+
+// ============================================================
+// Test 5: Unprojecting (cx, cy) gives optical axis [0, 0, 1]
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSUnprojectCenterPoint) {
+  auto cam = makeDSCamera();
+
+  std::vector<cv::Point2f> pts_2d = {
+      cv::Point2f(static_cast<float>(DS_CX), static_cast<float>(DS_CY))};
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  BOOST_CHECK_SMALL(double(rays[0].x), 1e-6);
+  BOOST_CHECK_SMALL(double(rays[0].y), 1e-6);
+  BOOST_CHECK_CLOSE(double(rays[0].z), 1.0, 0.01);
+}
+
+// ============================================================
+// Test 6: DS projection with non-identity pose
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSProjectionWithPose) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // Board-like pattern
+  std::vector<cv::Point3f> pts_3d;
+  for (int r = 0; r < 4; r++) {
+    for (int c = 0; c < 6; c++) {
+      pts_3d.emplace_back(c * 0.055f, r * 0.055f, 0.0f);
+    }
+  }
+
+  // Pose: slight rotation + translation
+  cv::Mat rvec = (cv::Mat_<double>(3, 1) << 0.1, -0.2, 0.15);
+  cv::Mat tvec = (cv::Mat_<double>(3, 1) << 0.05, -0.03, 0.8);
+
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  // All projected points should be within image bounds
+  for (const auto &pt : pts_2d) {
+    BOOST_CHECK_GE(pt.x, 0.0f);
+    BOOST_CHECK_LE(pt.x, 1920.0f);
+    BOOST_CHECK_GE(pt.y, 0.0f);
+    BOOST_CHECK_LE(pt.y, 1080.0f);
+  }
+
+  // Unproject and verify round-trip
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+  BOOST_CHECK_EQUAL(rays.size(), pts_2d.size());
+
+  // Transform original points to camera frame for direction comparison
+  cv::Mat R;
+  cv::Rodrigues(rvec, R);
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    double X = R.at<double>(0, 0) * pts_3d[i].x +
+               R.at<double>(0, 1) * pts_3d[i].y +
+               R.at<double>(0, 2) * pts_3d[i].z + tvec.at<double>(0);
+    double Y = R.at<double>(1, 0) * pts_3d[i].x +
+               R.at<double>(1, 1) * pts_3d[i].y +
+               R.at<double>(1, 2) * pts_3d[i].z + tvec.at<double>(1);
+    double Z = R.at<double>(2, 0) * pts_3d[i].x +
+               R.at<double>(2, 1) * pts_3d[i].y +
+               R.at<double>(2, 2) * pts_3d[i].z + tvec.at<double>(2);
+    double norm = std::sqrt(X * X + Y * Y + Z * Z);
+
+    BOOST_CHECK_CLOSE(double(rays[i].x), X / norm, 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].y), Y / norm, 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].z), Z / norm, 0.5);
+  }
+}
+
+// ============================================================
+// Test 7: Wide-angle points (edge of fisheye)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSWideAngleProjection) {
+  auto cam = makeDSCamera();
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // Points at various angles from optical axis
+  std::vector<cv::Point3f> pts_3d;
+  pts_3d.emplace_back(0.0f, 0.0f, 1.0f);   // on-axis
+  pts_3d.emplace_back(0.5f, 0.0f, 1.0f);   // ~26.5 deg off-axis
+  pts_3d.emplace_back(0.0f, 0.5f, 1.0f);   // ~26.5 deg off-axis
+  pts_3d.emplace_back(1.0f, 0.0f, 1.0f);   // ~45 deg off-axis
+  pts_3d.emplace_back(-1.0f, -1.0f, 1.0f); // ~54.7 deg off-axis
+
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+  std::vector<cv::Point2f> pts_2d;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       pts_2d);
+
+  // On-axis point should be at principal point
+  BOOST_CHECK_CLOSE(pts_2d[0].x, DS_CX, 0.01);
+  BOOST_CHECK_CLOSE(pts_2d[0].y, DS_CY, 0.01);
+
+  // Points right of center should have u > cx
+  BOOST_CHECK_GT(pts_2d[1].x, DS_CX);
+  // Points below center should have v > cy
+  BOOST_CHECK_GT(pts_2d[2].y, DS_CY);
+
+  // Symmetric points should be equidistant from center
+  float dist_right = pts_2d[1].x - static_cast<float>(DS_CX);
+  float dist_down = pts_2d[2].y - static_cast<float>(DS_CY);
+  // fx ~= fy, so horizontal and vertical offsets should be similar
+  BOOST_CHECK_CLOSE(dist_right, dist_down, 1.0);
+
+  // Round-trip all points
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+  for (size_t i = 0; i < pts_3d.size(); i++) {
+    float norm =
+        std::sqrt(pts_3d[i].x * pts_3d[i].x + pts_3d[i].y * pts_3d[i].y +
+                  pts_3d[i].z * pts_3d[i].z);
+    BOOST_CHECK_CLOSE(double(rays[i].x), double(pts_3d[i].x / norm), 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].y), double(pts_3d[i].y / norm), 0.5);
+    BOOST_CHECK_CLOSE(double(rays[i].z), double(pts_3d[i].z / norm), 0.5);
+  }
+}
+
+// ============================================================
+// Test 8: DS model vs Brown model on same point (sanity check)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSvsBrownDifferentProjection) {
+  auto ds_cam = makeDSCamera();
+  cv::Mat ds_cam_mat, ds_dist;
+  getCameraMatAndDist(ds_cam, ds_cam_mat, ds_dist);
+
+  // Brown camera with same focal length but no distortion
+  cv::Mat brown_cam_mat =
+      (cv::Mat_<double>(3, 3) << DS_FX, 0, DS_CX, 0, DS_FY, DS_CY, 0, 0, 1);
+  cv::Mat brown_dist = cv::Mat::zeros(1, 5, CV_64F);
+
+  // Off-axis point
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.5f, 0.3f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+
+  std::vector<cv::Point2f> ds_pts, brown_pts;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, ds_cam_mat, ds_dist,
+                                       2, ds_pts);
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, brown_cam_mat,
+                                       brown_dist, 0, brown_pts);
+
+  // DS and Brown should give DIFFERENT results (DS has additional distortion)
+  double diff = std::sqrt(std::pow(ds_pts[0].x - brown_pts[0].x, 2) +
+                          std::pow(ds_pts[0].y - brown_pts[0].y, 2));
+  BOOST_CHECK_GT(diff, 1.0); // Should differ by more than 1 pixel
+}
+
+// ============================================================
+// Test 9: DS distortion model type preserved in Camera
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSDistortionModelType) {
+  McCalib::Camera cam_brown(0, 0);
+  McCalib::Camera cam_kannala(1, 1);
+  McCalib::Camera cam_ds(2, 2);
+
+  BOOST_CHECK_EQUAL(cam_brown.distortion_model_, 0);
+  BOOST_CHECK_EQUAL(cam_kannala.distortion_model_, 1);
+  BOOST_CHECK_EQUAL(cam_ds.distortion_model_, 2);
+}
+
+// ============================================================
+// Test 10: Batch unprojection produces correct number of rays
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSUnprojectBatchSize) {
+  auto cam = makeDSCamera();
+
+  // Generate a grid of 2D points
+  std::vector<cv::Point2f> pts_2d;
+  for (int r = 0; r < 10; r++) {
+    for (int c = 0; c < 10; c++) {
+      pts_2d.emplace_back(400.0f + c * 100.0f, 200.0f + r * 60.0f);
+    }
+  }
+
+  std::vector<cv::Point3f> rays;
+  cam->dsUnproject(pts_2d, rays);
+
+  BOOST_CHECK_EQUAL(rays.size(), pts_2d.size());
+
+  // All rays should be unit vectors
+  for (const auto &ray : rays) {
+    double norm = std::sqrt(ray.x * ray.x + ray.y * ray.y + ray.z * ray.z);
+    BOOST_CHECK_CLOSE(norm, 1.0, 0.1);
+  }
+}
+
+// ============================================================
+// Test 11: Extreme DS parameters (boundary values)
+// ============================================================
+BOOST_AUTO_TEST_CASE(DSExtremParameterBounds) {
+  // Camera with xi=0, alpha=0 should behave like standard perspective
+  auto cam = std::make_shared<McCalib::Camera>(0, 2);
+  cam->im_cols_ = 1920;
+  cam->im_rows_ = 1080;
+  cam->intrinsics_[0] = 500.0;
+  cam->intrinsics_[1] = 500.0;
+  cam->intrinsics_[2] = 960.0;
+  cam->intrinsics_[3] = 540.0;
+  cam->intrinsics_[4] = 0.0; // xi = 0
+  cam->intrinsics_[5] = 0.0; // alpha = 0
+
+  cv::Mat cam_mat, dist_vec;
+  getCameraMatAndDist(cam, cam_mat, dist_vec);
+
+  // With xi=0, alpha=0, DS reduces to standard pinhole:
+  // d1 = ||P||, z1 = Z + 0 = Z, d2 = ||P||, den = 0 + 1*Z = Z
+  // u = fx * X/Z + cx (standard pinhole)
+  std::vector<cv::Point3f> pts_3d = {cv::Point3f(0.1f, -0.05f, 1.0f)};
+  cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64F);
+  cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64F);
+
+  std::vector<cv::Point2f> ds_pts;
+  McCalib::projectPointsWithDistortion(pts_3d, rvec, tvec, cam_mat, dist_vec, 2,
+                                       ds_pts);
+
+  // Expected pinhole projection: u = fx*X/Z + cx, v = fy*Y/Z + cy
+  double expected_u = 500.0 * 0.1 / 1.0 + 960.0;     // 1010
+  double expected_v = 500.0 * (-0.05) / 1.0 + 540.0; // 515
+
+  BOOST_CHECK_CLOSE(ds_pts[0].x, expected_u, 0.01);
+  BOOST_CHECK_CLOSE(ds_pts[0].y, expected_v, 0.01);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Add 11 Boost unit tests covering the DS camera model
- Add example config for heterogeneous 3-camera calibration (Brown + DS + Brown)

## Tests

| Test | Description |
|------|-------------|
| `DSDistortionStorageRoundTrip` | Set/get xi and alpha via distortion vector |
| `DSIntrinsicsZeroInit` | Verify unused intrinsics slots are zero |
| `DSProjectUnprojectRoundTrip` | Project-unproject cycle accuracy < 0.1px |
| `DSProjectionCenterPoint` | Optical axis maps to principal point |
| `DSUnprojectCenterPoint` | Principal point maps to (0,0,1) ray |
| `DSProjectionWithPose` | DS projection with non-identity extrinsics |
| `DSWideAngleProjection` | Wide-angle points project within image bounds |
| `DSvsBrownDifferentProjection` | DS and Brown produce different results |
| `DSDistortionModelType` | Model type preserved after construction |
| `DSUnprojectBatchSize` | Batch unprojection output size matches input |
| `DSExtremParameterBounds` | xi=0, alpha=0 reduces to pinhole behavior |

## Motivation

This is PR 4/4 in a series adding full DS support. Depends on #108.

The config demonstrates heterogeneous multi-camera calibration using
`distortion_per_camera: [0, 2, 0]` to assign different distortion models
per camera (0=Brown, 2=Double Sphere).

## Changes

| File | Change |
|------|--------|
| `tests/test_double_sphere.cpp` | New file: 11 Boost unit tests |
| `tests/CMakeLists.txt` | Add `test_double_sphere.cpp` to SOURCES |
| `configs/Real_images/calib_param_extrinsics_heterogeneous.yml` | Example heterogeneous config |

## Test Plan

- [ ] All 11 new DS tests pass
- [ ] Existing tests pass (no regressions)