### PR TITLE
Upgrade to opencv=v5.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
 
 env:
-  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv4100
-  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv4100
+  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv4110
+  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv4110
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -174,7 +174,7 @@ jobs:
               ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
 
 
-  unit-tests-in-release-mode-opencv4100:
+  unit-tests-in-release-mode-opencv4110:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -351,7 +351,7 @@ jobs:
   python-utils-linters:
     runs-on: ubuntu-latest
     needs:
-      - unit-tests-in-release-mode-opencv4100
+      - unit-tests-in-release-mode-opencv4110
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - python-utils-linters
-      - unit-tests-in-release-mode-opencv4100
+      - unit-tests-in-release-mode-opencv4110
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,62 @@ jobs:
           path: ${{ github.workspace }}/build/charuco_boards
 
 
+  test-charuco-boards-generation-opencv455:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run charuco boards generation app on OpenCV 4.5.5
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV455}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./apps/create_charuco_boards/generate_charuco ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+
+      - name: Archive results artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: charuco_boards_opencv455
+          path: ${{ github.workspace }}/build/charuco_boards
+
+
+  test-charuco-boards-generation-opencv420:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run charuco boards generation app on OpenCV 4.2.0
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV420}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./apps/create_charuco_boards/generate_charuco ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+
+      - name: Archive results artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: charuco_boards_opencv420
+          path: ${{ github.workspace }}/build/charuco_boards
+
+
   unit-tests-with-sanitizers:
     if: ${{ false }}  # TODO: disable for now until understand how to suppress leaks from external libraries like OpenCV
     runs-on: ubuntu-latest
@@ -447,7 +503,7 @@ jobs:
   python-utils-linters:
     runs-on: ubuntu-latest
     needs:
-      - unit-tests-in-release-mode-opencv4110
+      - unit-tests-in-release-mode-opencv500
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -467,7 +523,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - python-utils-linters
-      - unit-tests-in-release-mode-opencv4110
+      - unit-tests-in-release-mode-opencv500
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -475,7 +531,7 @@ jobs:
       - name: Download calibration results
         uses: actions/download-artifact@v4
         with:
-          name: results_blender_sequences
+          name: results_blender_sequences_opencv500
           path: ${{ github.workspace }}/data
 
       - name: Run python utils

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,14 +262,7 @@ jobs:
             done
             cp /home/MC-Calib/data/Blender_Images/Scenario_1/GroundTruth.yml "$subset_root/"
             cp ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml valgrind_scenario1.yml
-            python3 - <<'PY'
-from pathlib import Path
-path = Path("valgrind_scenario1.yml")
-text = path.read_text()
-text = text.replace("../data/Blender_Images/Scenario_1/Images", "/tmp/valgrind_subset/Scenario_1/Images")
-text = text.replace("../data/Blender_Images/Scenario_1/Results", "/tmp/valgrind_subset/Scenario_1/Results")
-path.write_text(text)
-PY
+            python3 -c "from pathlib import Path; path = Path('valgrind_scenario1.yml'); text = path.read_text(); text = text.replace('../data/Blender_Images/Scenario_1/Images', '/tmp/valgrind_subset/Scenario_1/Images'); text = text.replace('../data/Blender_Images/Scenario_1/Results', '/tmp/valgrind_subset/Scenario_1/Results'); path.write_text(text)"
             valgrind --leak-check=full \
               --leak-check=full \
               --track-origins=yes \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2  # required to mount the Github Workspace to a volume
+        uses: actions/checkout@v4  # required to mount the Github Workspace to a volume
 
       - name: Run clang-format-lint
         uses: DoozyX/clang-format-lint-action@v0.18.1
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run cppcheck
         uses: addnab/docker-run-action@v3
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run clang-tidy
         uses: addnab/docker-run-action@v3
@@ -84,7 +84,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run charuco boards generation app on OpenCV 4.11
         uses: addnab/docker-run-action@v3
@@ -112,7 +112,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run charuco boards generation app on OpenCV 5
         uses: addnab/docker-run-action@v3
@@ -140,7 +140,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run charuco boards generation app on OpenCV 4.5.5
         uses: addnab/docker-run-action@v3
@@ -168,7 +168,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run charuco boards generation app on OpenCV 4.2.0
         uses: addnab/docker-run-action@v3
@@ -197,7 +197,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -229,7 +229,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -272,7 +272,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -334,7 +334,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -396,7 +396,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -427,7 +427,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -458,7 +458,7 @@ jobs:
       - clang-tidy
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout MC-Calib-data
         uses: actions/checkout@v4
@@ -506,7 +506,7 @@ jobs:
       - unit-tests-in-release-mode-opencv500
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run python linters
         uses: addnab/docker-run-action@v3
@@ -526,7 +526,7 @@ jobs:
       - unit-tests-in-release-mode-opencv500
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download calibration results
         uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,7 @@ jobs:
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
-            cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=OFF ..
+            cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_SANITIZERS=OFF ..
             make -j4
             valgrind --leak-check=full \
               --leak-check=full \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,6 +250,26 @@ jobs:
             mkdir MC-Calib/build && cd MC-Calib/build
             cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_SANITIZERS=OFF ..
             make -j4
+            subset_root=/tmp/valgrind_subset/Scenario_1
+            subset_images="$subset_root/Images"
+            mkdir -p "$subset_images"
+            for camera_dir in /home/MC-Calib/data/Blender_Images/Scenario_1/Images/Cam_*; do
+              camera_name="$(basename "$camera_dir")"
+              mkdir -p "$subset_images/$camera_name"
+              find "$camera_dir" -maxdepth 1 -type f | sort | head -n 12 | while read -r image_path; do
+                cp "$image_path" "$subset_images/$camera_name/"
+              done
+            done
+            cp /home/MC-Calib/data/Blender_Images/Scenario_1/GroundTruth.yml "$subset_root/"
+            cp ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml valgrind_scenario1.yml
+            python3 - <<'PY'
+from pathlib import Path
+path = Path("valgrind_scenario1.yml")
+text = path.read_text()
+text = text.replace("../data/Blender_Images/Scenario_1/Images", "/tmp/valgrind_subset/Scenario_1/Images")
+text = text.replace("../data/Blender_Images/Scenario_1/Results", "/tmp/valgrind_subset/Scenario_1/Results")
+path.write_text(text)
+PY
             valgrind --leak-check=full \
               --leak-check=full \
               --track-origins=yes \
@@ -261,7 +281,7 @@ jobs:
               --suppressions=../tests/valgrind_suppress/opencv_valgrind.supp \
               --suppressions=../tests/valgrind_suppress/opencv_valgrind_3rdparty.supp \
               --suppressions=../tests/valgrind_suppress/boost_valgrind.supp \
-              ./apps/calibrate/calibrate ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+              ./apps/calibrate/calibrate valgrind_scenario1.yml
 
 
   unit-tests-in-release-mode-opencv4110:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,14 @@ on:
   workflow_dispatch:
 
 env:
-  MC_CALIB_PROD_DOCKER_IMG: bailool/mc-calib-prod:opencv4110
-  MC_CALIB_DEV_DOCKER_IMG: bailool/mc-calib-dev:opencv4110
+  MC_CALIB_PROD_DOCKER_IMG_OPENCV500: bailool/mc-calib-prod:opencv500
+  MC_CALIB_DEV_DOCKER_IMG_OPENCV500: bailool/mc-calib-dev:opencv500
+  MC_CALIB_PROD_DOCKER_IMG_OPENCV4110: bailool/mc-calib-prod:opencv4110
+  MC_CALIB_DEV_DOCKER_IMG_OPENCV4110: bailool/mc-calib-dev:opencv4110
+  MC_CALIB_PROD_DOCKER_IMG_OPENCV455: bailool/mc-calib-prod:opencv455
+  MC_CALIB_DEV_DOCKER_IMG_OPENCV455: bailool/mc-calib-dev:opencv455
+  MC_CALIB_PROD_DOCKER_IMG_OPENCV420: bailool/mc-calib-prod:opencv420
+  MC_CALIB_DEV_DOCKER_IMG_OPENCV420: bailool/mc-calib-dev:opencv420
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -46,7 +52,7 @@ jobs:
       - name: Run cppcheck
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             cppcheck MC-Calib/McCalib/include
@@ -62,7 +68,7 @@ jobs:
       - name: Run clang-tidy
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -70,7 +76,7 @@ jobs:
             run-clang-tidy
   
 
-  test-charuco-boards-generation:
+  test-charuco-boards-generation-opencv4110:
     runs-on: ubuntu-latest
     needs:
       - clang-format-lint
@@ -80,10 +86,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Run charuco boards generation app
+      - name: Run charuco boards generation app on OpenCV 4.11
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV4110}}
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -94,7 +100,35 @@ jobs:
       - name: Archive results artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: charuco_boards
+          name: charuco_boards_opencv4110
+          path: ${{ github.workspace }}/build/charuco_boards
+
+
+  test-charuco-boards-generation-opencv500:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run charuco boards generation app on OpenCV 5
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV500}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./apps/create_charuco_boards/generate_charuco ../tests/configs_for_end2end_tests/calib_param_synth_Scenario1.yml
+
+      - name: Archive results artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: charuco_boards_opencv500
           path: ${{ github.workspace }}/build/charuco_boards
 
 
@@ -122,7 +156,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -154,7 +188,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -194,10 +228,10 @@ jobs:
       - name: Unzip MC-Calib-data
         run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
         
-      - name: Run tests
+      - name: Run tests on OpenCV 4.11
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV4110}}
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -236,6 +270,68 @@ jobs:
           name: results_blender_sequences
           path: ${{ github.workspace }}/data/Blender_Images/Results_Blender_Sequences
 
+  unit-tests-in-release-mode-opencv500:
+    runs-on: ubuntu-latest
+    needs:
+      - clang-format-lint
+      - cppcheck
+      - clang-tidy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout MC-Calib-data
+        uses: actions/checkout@v4
+        with:
+          repository: BAILOOL/MC-Calib-data
+          path: ${{ github.workspace }}/data
+          lfs: 'true'
+
+      - name: Unzip MC-Calib-data
+        run: tar xf ${{ github.workspace }}/data/Blender_Images.tar.gz -C ${{ github.workspace }}/data
+        
+      - name: Run tests on OpenCV 5
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV500}}
+          options: -v ${{ github.workspace }}:/home/MC-Calib:rw
+          run: |
+            mkdir MC-Calib/build && cd MC-Calib/build
+            cmake -DCMAKE_BUILD_TYPE=Release ..
+            make -j4
+            ./tests/boost_tests_run
+
+      - name: Collect results
+        run: |
+          cd ${{ github.workspace }}/data/Blender_Images
+          mkdir Results_Blender_Sequences
+
+          mkdir Results_Blender_Sequences/Scenario_1
+          cp -r Scenario_1/Results Results_Blender_Sequences/Scenario_1
+          cp Scenario_1/GroundTruth.yml Results_Blender_Sequences/Scenario_1
+
+          mkdir Results_Blender_Sequences/Scenario_2
+          cp -r Scenario_2/Results Results_Blender_Sequences/Scenario_2
+          cp Scenario_2/GroundTruth.yml Results_Blender_Sequences/Scenario_2
+
+          mkdir Results_Blender_Sequences/Scenario_3
+          cp -r Scenario_3/Results Results_Blender_Sequences/Scenario_3
+          cp Scenario_3/GroundTruth.yml Results_Blender_Sequences/Scenario_3
+
+          mkdir Results_Blender_Sequences/Scenario_4
+          cp -r Scenario_4/Results Results_Blender_Sequences/Scenario_4
+          cp Scenario_4/GroundTruth.yml Results_Blender_Sequences/Scenario_4
+
+          mkdir Results_Blender_Sequences/Scenario_5
+          cp -r Scenario_5/Results Results_Blender_Sequences/Scenario_5
+          cp Scenario_5/GroundTruth.yml Results_Blender_Sequences/Scenario_5
+
+      - name: Archive results artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: results_blender_sequences_opencv500
+          path: ${{ github.workspace }}/data/Blender_Images/Results_Blender_Sequences
+
   unit-tests-in-release-mode-opencv455:
     runs-on: ubuntu-latest
     needs:
@@ -259,7 +355,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: bailool/mc-calib-prod:opencv455
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV455}}
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -290,7 +386,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: bailool/mc-calib-prod:opencv420
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV420}}
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             mkdir MC-Calib/build && cd MC-Calib/build
@@ -321,7 +417,7 @@ jobs:
       - name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:${{ github.workspace }}
           run: |
             mkdir ${{ github.workspace }}/build && cd ${{ github.workspace }}/build
@@ -359,7 +455,7 @@ jobs:
       - name: Run python linters
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_DEV_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_DEV_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib
           run: |
             cd MC-Calib/python_utils
@@ -385,7 +481,7 @@ jobs:
       - name: Run python utils
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{env.MC_CALIB_PROD_DOCKER_IMG}}
+          image: ${{env.MC_CALIB_PROD_DOCKER_IMG_OPENCV500}}
           options: -v ${{ github.workspace }}:/home/MC-Calib:rw
           run: |
             cd MC-Calib/python_utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE STRING "" FORCE)
 
 find_package(OpenCV REQUIRED)
 include_directories( ${OpenCV_INCLUDE_DIRS} )
+message(STATUS "Found OpenCV version: ${OpenCV_VERSION}")
+
+if(OpenCV_VERSION VERSION_LESS "4.2.0")
+  message(FATAL_ERROR "MC-Calib requires OpenCV >= 4.2.0")
+endif()
 
 find_package(Ceres REQUIRED)
 
@@ -50,7 +55,6 @@ endif()
 
 include_directories(
 	include
-	/usr/include/opencv
 	/usr/include/eigen3
 	/usr/local/lib
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ WORKDIR /home
 #------------------------------	#
 #     INSTALL OPENCV 4		    #
 #------------------------------	#
-RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.10.0.zip && \
-	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/4.10.0.zip && \
+RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.11.0.zip && \
+	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/4.11.0.zip && \
 	unzip opencv.zip && unzip opencv_contrib.zip && \
 	mkdir -p build && cd build && \
-	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-4.10.0/modules ../opencv-4.10.0 && \
+	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-4.11.0/modules ../opencv-4.11.0 && \
 	cmake --build . --target install -- -j4 && \
 	cd /home && rm opencv.zip && rm opencv_contrib.zip && \ 
-	rm -rf opencv-4.10.0 && rm -rf opencv_contrib-4.10.0 && rm -rf build && \
+	rm -rf opencv-4.11.0 && rm -rf opencv_contrib-4.11.0 && rm -rf build && \
 	rm -rf /var/lib/apt/lists/*
 
 #------------------------------	#

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,16 @@ ENV NO_AT_BRIDGE 1
 WORKDIR /home
 
 #------------------------------	#
-#     INSTALL OPENCV 4		    #
+#     INSTALL OPENCV 5		    #
 #------------------------------	#
-RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.11.0.zip && \
-	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/4.11.0.zip && \
+RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/5.0.0.zip && \
+	wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/5.0.0.zip && \
 	unzip opencv.zip && unzip opencv_contrib.zip && \
 	mkdir -p build && cd build && \
-	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-4.11.0/modules ../opencv-4.11.0 && \
+	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-5.0.0/modules ../opencv-5.0.0 && \
 	cmake --build . --target install -- -j4 && \
 	cd /home && rm opencv.zip && rm opencv_contrib.zip && \ 
-	rm -rf opencv-4.11.0 && rm -rf opencv_contrib-4.11.0 && rm -rf build && \
+	rm -rf opencv-5.0.0 && rm -rf opencv_contrib-5.0.0 && rm -rf build && \
 	rm -rf /var/lib/apt/lists/*
 
 #------------------------------	#

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/5.0.0.zip && \
 	mkdir -p build && cd build && \
 	cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-5.0.0/modules ../opencv-5.0.0 && \
 	cmake --build . --target install -- -j4 && \
-	cd /home && rm opencv.zip && rm opencv_contrib.zip && \ 
+	cd /home && rm opencv.zip && rm opencv_contrib.zip && \
 	rm -rf opencv-5.0.0 && rm -rf opencv_contrib-5.0.0 && rm -rf build && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -49,7 +49,7 @@ RUN git clone --branch 2.2.0 --single-branch https://github.com/ceres-solver/cer
 
 # Install python requirements for python_utils scripts
 RUN --mount=type=bind,source=python_utils/requirements_prod.txt,target=/tmp/requirements.txt \
-	apt update && apt install -y libgl1 libglib2.0-0 && \    
+	apt update && apt install -y libgl1 libglib2.0-0 && \
 	python -m pip install --requirement /tmp/requirements.txt --break-system-packages && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -58,11 +58,11 @@ FROM prod as dev
 #------------------------------	#
 #     Doxygen				    #
 #------------------------------	#
-RUN apt update && apt install -y flex bison && \ 
+RUN apt update && apt install -y flex bison && \
 	git clone https://github.com/doxygen/doxygen.git && \
 	cd doxygen && mkdir build && cd build &&\
 	cmake -G 'Unix Makefiles' .. && \
-	make -j4 && \ 
+	make -j4 && \
 	make -j4 install && \
 	cd /home && rm -rf doxygen && \
 	rm -rf /var/lib/apt/lists/*

--- a/McCalib/include/Board.hpp
+++ b/McCalib/include/Board.hpp
@@ -4,8 +4,8 @@
 #include <iostream>
 
 #include "opencv2/core/core.hpp"
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/Board.hpp
+++ b/McCalib/include/Board.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/BoardObs.hpp
+++ b/McCalib/include/BoardObs.hpp
@@ -3,7 +3,7 @@
 #include "Board.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/BoardObs.hpp
+++ b/McCalib/include/BoardObs.hpp
@@ -3,8 +3,8 @@
 #include "Board.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -2,8 +2,8 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "Board.hpp"

--- a/McCalib/include/Camera.hpp
+++ b/McCalib/include/Camera.hpp
@@ -2,7 +2,7 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/CameraGroup.hpp
+++ b/McCalib/include/CameraGroup.hpp
@@ -2,8 +2,8 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "Board.hpp"

--- a/McCalib/include/CameraGroup.hpp
+++ b/McCalib/include/CameraGroup.hpp
@@ -2,7 +2,7 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/CameraGroupObs.hpp
+++ b/McCalib/include/CameraGroupObs.hpp
@@ -4,7 +4,7 @@
 #include "Object3DObs.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/CameraGroupObs.hpp
+++ b/McCalib/include/CameraGroupObs.hpp
@@ -4,8 +4,8 @@
 #include "Object3DObs.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/CameraObs.hpp
+++ b/McCalib/include/CameraObs.hpp
@@ -4,7 +4,7 @@
 #include "Object3DObs.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/CameraObs.hpp
+++ b/McCalib/include/CameraObs.hpp
@@ -4,8 +4,8 @@
 #include "Object3DObs.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/Frame.hpp
+++ b/McCalib/include/Frame.hpp
@@ -5,8 +5,8 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 
 #include "BoardObs.hpp"
 #include "CameraGroupObs.hpp"

--- a/McCalib/include/Frame.hpp
+++ b/McCalib/include/Frame.hpp
@@ -5,7 +5,7 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 
 #include "BoardObs.hpp"

--- a/McCalib/include/McCalib.hpp
+++ b/McCalib/include/McCalib.hpp
@@ -7,7 +7,6 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
 #include <opencv2/calib3d.hpp>
 #include <opencv2/opencv.hpp>
 
@@ -21,6 +20,7 @@
 #include "Graph.hpp"
 #include "Object3D.hpp"
 #include "Object3DObs.hpp"
+#include "opencv_compat.hpp"
 #include "geometrytools.hpp"
 
 namespace McCalib {
@@ -37,8 +37,7 @@ public:
   // Parameters
   unsigned int nb_camera_, nb_board_;
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
   cv::Ptr<cv::aruco::Dictionary> dict_ = cv::aruco::getPredefinedDictionary(
       cv::aruco::DICT_6X6_1000); // load the dictionary that correspond to the
                                  // charuco board

--- a/McCalib/include/McCalib.hpp
+++ b/McCalib/include/McCalib.hpp
@@ -20,8 +20,8 @@
 #include "Graph.hpp"
 #include "Object3D.hpp"
 #include "Object3DObs.hpp"
-#include "opencv_compat.hpp"
 #include "geometrytools.hpp"
+#include "opencv_compat.hpp"
 
 namespace McCalib {
 

--- a/McCalib/include/Object3D.hpp
+++ b/McCalib/include/Object3D.hpp
@@ -2,7 +2,7 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/Object3D.hpp
+++ b/McCalib/include/Object3D.hpp
@@ -2,8 +2,8 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/Object3DObs.hpp
+++ b/McCalib/include/Object3DObs.hpp
@@ -4,7 +4,7 @@
 #include "Object3D.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/include/Object3DObs.hpp
+++ b/McCalib/include/Object3DObs.hpp
@@ -4,8 +4,8 @@
 #include "Object3D.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 namespace McCalib {

--- a/McCalib/include/geometrytools.hpp
+++ b/McCalib/include/geometrytools.hpp
@@ -2,6 +2,8 @@
 
 #include "opencv2/core/core.hpp"
 #include <iostream>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
 #include <opencv2/opencv.hpp>
 #include <random>
 #include <stdio.h>

--- a/McCalib/include/opencv_compat.hpp
+++ b/McCalib/include/opencv_compat.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <opencv2/core/version.hpp>
+
+// OpenCV 4.x ships ChArUco in opencv2/aruco/charuco.hpp.
+// OpenCV 5.x may expose it via objdetect headers.
+#if __has_include(<opencv2/aruco/charuco.hpp>)
+#include <opencv2/aruco/charuco.hpp>
+#define MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE 1
+#elif __has_include(<opencv2/objdetect/charuco_detector.hpp>)
+#include <opencv2/objdetect/aruco_detector.hpp>
+#include <opencv2/objdetect/charuco_detector.hpp>
+#define MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE 0
+#elif __has_include(<opencv2/objdetect.hpp>)
+#include <opencv2/objdetect.hpp>
+#define MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE 0
+#else
+#error "Could not find OpenCV ArUco/ChArUco headers. Install OpenCV with contrib modules."
+#endif
+
+// Helper macro for version-based OpenCV API switches.
+#define MC_CALIB_OPENCV_AT_LEAST(major, minor)                                 \
+  ((CV_VERSION_MAJOR > (major)) ||                                             \
+   (CV_VERSION_MAJOR == (major) && CV_VERSION_MINOR >= (minor)))
+
+// ArUco API changed in OpenCV 4.7.
+#define MC_CALIB_USE_LEGACY_ARUCO_API (!MC_CALIB_OPENCV_AT_LEAST(4, 7))

--- a/McCalib/include/opencv_compat.hpp
+++ b/McCalib/include/opencv_compat.hpp
@@ -15,7 +15,8 @@
 #include <opencv2/objdetect.hpp>
 #define MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE 0
 #else
-#error "Could not find OpenCV ArUco/ChArUco headers. Install OpenCV with contrib modules."
+#error                                                                         \
+    "Could not find OpenCV ArUco/ChArUco headers. Install OpenCV with contrib modules."
 #endif
 
 // Helper macro for version-based OpenCV API switches.

--- a/McCalib/include/utilities.hpp
+++ b/McCalib/include/utilities.hpp
@@ -4,8 +4,9 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/aruco/charuco.hpp>
 #include <opencv2/opencv.hpp>
+
+#include "opencv_compat.hpp"
 
 namespace McCalib {
 
@@ -13,8 +14,7 @@ std::filesystem::path convertStrToPath(const std::string &item_name);
 std::vector<std::filesystem::path>
 convertVecStrToVecPath(const std::vector<std::string> &input);
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
 
 std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
 createCharucoBoards(const unsigned int num_board,

--- a/McCalib/src/Board.cpp
+++ b/McCalib/src/Board.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 
 #include "Board.hpp"

--- a/McCalib/src/Board.cpp
+++ b/McCalib/src/Board.cpp
@@ -4,8 +4,8 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 
 #include "Board.hpp"
 #include "Frame.hpp"

--- a/McCalib/src/BoardObs.cpp
+++ b/McCalib/src/BoardObs.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "BoardObs.hpp"

--- a/McCalib/src/BoardObs.cpp
+++ b/McCalib/src/BoardObs.cpp
@@ -1,6 +1,6 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 
 #include "Camera.hpp"

--- a/McCalib/src/Camera.cpp
+++ b/McCalib/src/Camera.cpp
@@ -4,8 +4,8 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 
 #include "Camera.hpp"
 #include "OptimizationCeres.h"

--- a/McCalib/src/CameraGroup.cpp
+++ b/McCalib/src/CameraGroup.cpp
@@ -2,8 +2,8 @@
 #include "geometrytools.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "CameraGroup.hpp"

--- a/McCalib/src/CameraGroup.cpp
+++ b/McCalib/src/CameraGroup.cpp
@@ -2,7 +2,7 @@
 #include "geometrytools.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/CameraGroupObs.cpp
+++ b/McCalib/src/CameraGroupObs.cpp
@@ -2,8 +2,8 @@
 #include "geometrytools.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "CameraGroupObs.hpp"

--- a/McCalib/src/CameraGroupObs.cpp
+++ b/McCalib/src/CameraGroupObs.cpp
@@ -2,7 +2,7 @@
 #include "geometrytools.hpp"
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/CameraObs.cpp
+++ b/McCalib/src/CameraObs.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "CameraObs.hpp"

--- a/McCalib/src/CameraObs.cpp
+++ b/McCalib/src/CameraObs.cpp
@@ -1,6 +1,6 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/Frame.cpp
+++ b/McCalib/src/Frame.cpp
@@ -2,8 +2,8 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 
 #include "Frame.hpp"
 

--- a/McCalib/src/Frame.cpp
+++ b/McCalib/src/Frame.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 #include "opencv2/core/core.hpp"
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 
 #include "Frame.hpp"

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -1,6 +1,6 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <random>
 #include <stdio.h>
@@ -290,8 +290,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string &frame_path,
   // key == board id, value == ID corners on checkerboard
   std::map<int, std::vector<int>> charuco_idx;
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
   charuco_params_->adaptiveThreshConstant = 1;
 #else
   charuco_params_.adaptiveThreshConstant = 1;
@@ -299,8 +298,7 @@ void Calibration::detectBoardsInImageWithCamera(const std::string &frame_path,
 
   for (std::size_t i = 0; i < nb_board_; i++) {
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
 
     cv::aruco::detectMarkers(image, boards_3d_[i]->charuco_board_->dictionary,
                              marker_corners[i], marker_idx[i], charuco_params_);
@@ -312,9 +310,15 @@ void Calibration::detectBoardsInImageWithCamera(const std::string &frame_path,
 #endif
 
     if (marker_corners[i].size() > 0) {
+  #if MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE
       cv::aruco::interpolateCornersCharuco(marker_corners[i], marker_idx[i],
-                                           image, boards_3d_[i]->charuco_board_,
-                                           charuco_corners[i], charuco_idx[i]);
+                         image, boards_3d_[i]->charuco_board_,
+                         charuco_corners[i], charuco_idx[i]);
+  #else
+      cv::aruco::CharucoDetector detector(*boards_3d_[i]->charuco_board_);
+      detector.detectBoard(image, charuco_corners[i], charuco_idx[i],
+                 marker_corners[i], marker_idx[i]);
+  #endif
     }
 
     if (charuco_corners[i].size() >
@@ -885,9 +889,8 @@ void Calibration::init3DObjects() {
       std::vector<int> short_path = covis_boards_graph_.shortestPathBetween(
           ref_board_id, current_board_id);
       // Compute the transformation wrt. the reference board
-      cv::Mat transform = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0,
-                           0, 1, 0, 0, 0, 0,
-                           1); // initialize the transformation to identity
+        cv::Mat transform =
+          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1118,9 +1121,8 @@ void Calibration::initCameraGroup() {
       std::vector<int> short_path = covis_camera_graph_.shortestPathBetween(
           id_ref_cam, current_camera_id);
       // Compute the transformation wrt. the reference camera
-      cv::Mat transform =
-          (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0,
-           0, 1); // initialize the transformation to identity
+        cv::Mat transform =
+          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1553,9 +1555,8 @@ void Calibration::mergeCameraGroup() {
           no_overlap_camgroup_graph_.shortestPathBetween(id_ref_cam_group,
                                                          current_cam_group_id);
       // Compute the transformation wrt. the reference camera
-      cv::Mat transform =
-          (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0,
-           0, 1); // initialize the transformation to identity
+        cv::Mat transform =
+          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1738,9 +1739,8 @@ void Calibration::mergeObjects() {
       std::vector<int> short_path = covis_objects_graph_.shortestPathBetween(
           id_ref_object, current_object_id);
       // Compute the transformation wrt. the reference object
-      cv::Mat transform =
-          (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0,
-           0, 1); // initialize the transformation to identity
+        cv::Mat transform =
+          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {

--- a/McCalib/src/McCalib.cpp
+++ b/McCalib/src/McCalib.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <random>
 #include <stdio.h>
 
@@ -310,15 +310,15 @@ void Calibration::detectBoardsInImageWithCamera(const std::string &frame_path,
 #endif
 
     if (marker_corners[i].size() > 0) {
-  #if MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE
+#if MC_CALIB_HAS_LEGACY_CHARUCO_INTERPOLATE
       cv::aruco::interpolateCornersCharuco(marker_corners[i], marker_idx[i],
-                         image, boards_3d_[i]->charuco_board_,
-                         charuco_corners[i], charuco_idx[i]);
-  #else
+                                           image, boards_3d_[i]->charuco_board_,
+                                           charuco_corners[i], charuco_idx[i]);
+#else
       cv::aruco::CharucoDetector detector(*boards_3d_[i]->charuco_board_);
       detector.detectBoard(image, charuco_corners[i], charuco_idx[i],
-                 marker_corners[i], marker_idx[i]);
-  #endif
+                           marker_corners[i], marker_idx[i]);
+#endif
     }
 
     if (charuco_corners[i].size() >
@@ -889,8 +889,8 @@ void Calibration::init3DObjects() {
       std::vector<int> short_path = covis_boards_graph_.shortestPathBetween(
           ref_board_id, current_board_id);
       // Compute the transformation wrt. the reference board
-        cv::Mat transform =
-          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
+      cv::Mat transform = cv::Mat::eye(
+          4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1121,8 +1121,8 @@ void Calibration::initCameraGroup() {
       std::vector<int> short_path = covis_camera_graph_.shortestPathBetween(
           id_ref_cam, current_camera_id);
       // Compute the transformation wrt. the reference camera
-        cv::Mat transform =
-          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
+      cv::Mat transform = cv::Mat::eye(
+          4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1555,8 +1555,8 @@ void Calibration::mergeCameraGroup() {
           no_overlap_camgroup_graph_.shortestPathBetween(id_ref_cam_group,
                                                          current_cam_group_id);
       // Compute the transformation wrt. the reference camera
-        cv::Mat transform =
-          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
+      cv::Mat transform = cv::Mat::eye(
+          4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {
@@ -1739,8 +1739,8 @@ void Calibration::mergeObjects() {
       std::vector<int> short_path = covis_objects_graph_.shortestPathBetween(
           id_ref_object, current_object_id);
       // Compute the transformation wrt. the reference object
-        cv::Mat transform =
-          cv::Mat::eye(4, 4, CV_64F); // initialize the transformation to identity
+      cv::Mat transform = cv::Mat::eye(
+          4, 4, CV_64F); // initialize the transformation to identity
 
       if (short_path.size() >= 1u) {
         for (std::size_t k = 0; k < short_path.size() - 1; k++) {

--- a/McCalib/src/Object3D.cpp
+++ b/McCalib/src/Object3D.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "Camera.hpp"

--- a/McCalib/src/Object3D.cpp
+++ b/McCalib/src/Object3D.cpp
@@ -1,6 +1,6 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/Object3DObs.cpp
+++ b/McCalib/src/Object3DObs.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 #include <stdio.h>
 
 #include "Camera.hpp"

--- a/McCalib/src/Object3DObs.cpp
+++ b/McCalib/src/Object3DObs.cpp
@@ -1,6 +1,6 @@
 #include "opencv2/core/core.hpp"
 #include <iostream>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 #include <stdio.h>
 

--- a/McCalib/src/geometrytools.cpp
+++ b/McCalib/src/geometrytools.cpp
@@ -12,8 +12,7 @@ namespace McCalib {
 
 // Tools for rotation and projection matrix
 cv::Mat RT2Proj(const cv::Mat &R, const cv::Mat &T) {
-  cv::Mat Proj = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
-                  0, 0, 0, 1);
+  cv::Mat Proj = cv::Mat::eye(4, 4, CV_64F);
   R.copyTo(Proj(cv::Range(0, 3), cv::Range(0, 3)));
   T.copyTo(Proj(cv::Range(0, 3), cv::Range(3, 4)));
   return Proj;
@@ -22,8 +21,7 @@ cv::Mat RT2Proj(const cv::Mat &R, const cv::Mat &T) {
 cv::Mat RVecT2Proj(const cv::Mat &RVec, const cv::Mat &T) {
   cv::Mat R;
   cv::Rodrigues(RVec, R);
-  cv::Mat Proj = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
-                  0, 0, 0, 1);
+  cv::Mat Proj = cv::Mat::eye(4, 4, CV_64F);
   R.copyTo(Proj(cv::Range(0, 3), cv::Range(0, 3)));
   T.copyTo(Proj(cv::Range(0, 3), cv::Range(3, 4)));
   return Proj;
@@ -32,8 +30,7 @@ cv::Mat RVecT2Proj(const cv::Mat &RVec, const cv::Mat &T) {
 cv::Mat RVecT2ProjInt(const cv::Mat &RVec, const cv::Mat &T, const cv::Mat &K) {
   cv::Mat R;
   cv::Rodrigues(RVec, R);
-  cv::Mat Proj = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
-                  0, 0, 0, 1);
+  cv::Mat Proj = cv::Mat::eye(4, 4, CV_64F);
   cv::Mat KR = K * R;
   cv::Mat KT = K * T;
   KR.copyTo(Proj(cv::Range(0, 3), cv::Range(0, 3)));
@@ -60,8 +57,7 @@ cv::Mat vectorProj(const std::vector<float> &ProjV) // R Rodrigues | T vector
   TV.at<double>(0) = (double)ProjV[3];
   TV.at<double>(1) = (double)ProjV[4];
   TV.at<double>(2) = (double)ProjV[5];
-  cv::Mat Proj = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
-                  0, 0, 0, 1);
+  cv::Mat Proj = cv::Mat::eye(4, 4, CV_64F);
   R.copyTo(Proj(cv::Range(0, 3), cv::Range(0, 3)));
   TV.copyTo(Proj(cv::Range(0, 3), cv::Range(3, 4)));
   return Proj;
@@ -133,7 +129,7 @@ void calcLinePara(const std::vector<cv::Point2f> &pts, double &a, double &b,
   for (const auto &pt : pts)
     ptsF.emplace_back(pt);
 
-  cv::fitLine(ptsF, line, cv::DistanceTypes::DIST_L2, 0, 1e-2, 1e-2);
+  cv::fitLine(ptsF, line, cv::DIST_L2, 0, 1e-2, 1e-2);
   a = line[1];
   b = -line[0];
   c = line[0] * line[3] - line[1] * line[2];
@@ -740,8 +736,7 @@ cv::Mat ransacP3PDistortion(const std::vector<cv::Point3f> &scene_points,
           float(intrinsic.at<double>(1, 2));
     }
     // Run p3p
-    const cv::Mat zero_distortion_vector =
-        (cv::Mat_<double>(1, 5) << 0, 0, 0, 0, 0);
+    const cv::Mat zero_distortion_vector = cv::Mat::zeros(1, 5, CV_64F);
     Inliers = ransacP3P(scene_points, imagePointsUndis, New_Intrinsic,
                         zero_distortion_vector, best_R, best_T, thresh, it, p,
                         refine);

--- a/McCalib/src/utilities.cpp
+++ b/McCalib/src/utilities.cpp
@@ -20,8 +20,7 @@ convertVecStrToVecPath(const std::vector<std::string> &input) {
   return out;
 }
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
 
 std::map<int, cv::Ptr<cv::aruco::CharucoBoard>>
 createCharucoBoards(const unsigned int num_board,

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0}, c++17
 - Pull the image:
 
    ```bash
-   docker pull bailool/mc-calib-prod:opencv4100 # production environment
-   docker pull bailool/mc-calib-dev:opencv4100  # development environment
+   docker pull bailool/mc-calib-prod:opencv4110 # production environment
+   docker pull bailool/mc-calib-dev:opencv4110  # development environment
    ```
 
 - Run pulled image (set `PATH_TO_REPO_ROOT` and `PATH_TO_DATA` appropriately):
@@ -27,7 +27,7 @@ Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0}, c++17
                -ti --rm \
                --volume="$PATH_TO_REPO_ROOT:/home/MC-Calib" \
                --volume="$PATH_TO_DATA:/home/MC-Calib/data" \
-               bailool/mc-calib-prod:opencv4100
+               bailool/mc-calib-prod:opencv4110
    ```
       
 Compiling the code:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ Toolbox described in the paper ["MC-Calib: A generic and robust calibration tool
 
 For Windows users, follow [this installation guide](/docs/Windows.md).
 
-Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0, 4.11.0}, c++17 
+Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0, 4.11.0, 5.0.0}, c++17 
 
 - [Install](https://docs.docker.com/engine/install/) docker
 
 - Pull the image:
 
    ```bash
-   docker pull bailool/mc-calib-prod:opencv4110 # production environment
-   docker pull bailool/mc-calib-dev:opencv4110  # development environment
+   docker pull bailool/mc-calib-prod:opencv500 # production environment (recommended)
+   docker pull bailool/mc-calib-dev:opencv500  # development environment (recommended)
+   # legacy compatibility images are also available (opencv4110, opencv455, opencv420)
    ```
 
 - Run pulled image (set `PATH_TO_REPO_ROOT` and `PATH_TO_DATA` appropriately):
@@ -27,7 +28,7 @@ Requirements: Ceres, Boost, OpenCV {4.2.0, 4.5.5, 4.10.0, 4.11.0}, c++17
                -ti --rm \
                --volume="$PATH_TO_REPO_ROOT:/home/MC-Calib" \
                --volume="$PATH_TO_DATA:/home/MC-Calib/data" \
-               bailool/mc-calib-prod:opencv4110
+               bailool/mc-calib-prod:opencv500
    ```
       
 Compiling the code:

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -28,8 +28,8 @@ This documentation is meant to guide the installation of the MC-Calib toolbox, s
    Then pull the docker image using either one of the commands given below.
 
 ```bash
-docker pull bailool/mc-calib-prod:opencv4100 # production environment
-docker pull bailool/mc-calib-dev:opencv4100 # development environment
+docker pull bailool/mc-calib-prod:opencv4110 # production environment
+docker pull bailool/mc-calib-dev:opencv4110 # development environment
 ```
 
 4. **Running Pulled Image using Docker**  
@@ -41,7 +41,7 @@ Docker run `
     -ti --rm `
     --volume=”$PATH_TO_REPO_ROOT:/home/MC-Calib” `
     --volume=”$PATH_TO_DATA:/home/MC-Calib/data” `
-    bailool/mc-calib-prod:opencv4100
+    bailool/mc-calib-prod:opencv4110
 ```
 
 ### User Personalization

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -28,8 +28,9 @@ This documentation is meant to guide the installation of the MC-Calib toolbox, s
    Then pull the docker image using either one of the commands given below.
 
 ```bash
-docker pull bailool/mc-calib-prod:opencv4110 # production environment
-docker pull bailool/mc-calib-dev:opencv4110 # development environment
+docker pull bailool/mc-calib-prod:opencv500 # production environment (recommended)
+docker pull bailool/mc-calib-dev:opencv500 # development environment (recommended)
+# legacy compatibility images are also available (opencv4110, opencv455, opencv420)
 ```
 
 4. **Running Pulled Image using Docker**  
@@ -41,7 +42,7 @@ Docker run `
     -ti --rm `
     --volume=”$PATH_TO_REPO_ROOT:/home/MC-Calib” `
     --volume=”$PATH_TO_DATA:/home/MC-Calib/data” `
-    bailool/mc-calib-prod:opencv4110
+   bailool/mc-calib-prod:opencv500
 ```
 
 ### User Personalization

--- a/tests/simple_unit_tests_example.cpp
+++ b/tests/simple_unit_tests_example.cpp
@@ -8,8 +8,7 @@
 BOOST_AUTO_TEST_SUITE(CheckGeometryTools)
 
 BOOST_AUTO_TEST_CASE(ProjToVecAllZeros) {
-  cv::Mat proj_matrix = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-                         1, 0, 0, 0, 0, 1);
+  cv::Mat proj_matrix = cv::Mat::eye(4, 4, CV_64F);
   std::array<float, 6> output = McCalib::ProjToVec(proj_matrix);
 
   std::array<float, 6> answer = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};

--- a/tests/test_calibration.cpp
+++ b/tests/test_calibration.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #include <boost/test/unit_test.hpp>
-#include <opencv2/aruco/charuco.hpp>
+#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
 
 #include <McCalib.hpp>
@@ -14,8 +14,7 @@
 constexpr double INTRINSICS_TOLERANCE = 4.0;     // in percentage
 constexpr double ROTATION_ERROR_TOLERANCE = 1.0; // in degrees
 
-#if (defined(CV_VERSION_MAJOR) && CV_VERSION_MAJOR <= 4 &&                     \
-     defined(CV_VERSION_MINOR) && CV_VERSION_MINOR < 7)
+#if MC_CALIB_USE_LEGACY_ARUCO_API
 constexpr double TRANSLATION_ERROR_TOLERANCE = 0.005; // in meters
 #else
 constexpr double TRANSLATION_ERROR_TOLERANCE = 0.01; // in meters
@@ -86,8 +85,9 @@ void calibrateAndCheckGt(const std::filesystem::path &config_path,
     fs["P_" + std::to_string(camera_idx)] >> camera_pose_matrix_gt;
 
     // blender images has different axis orientation, correct to match opencv
-    cv::Mat transform = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, -1, 0, 0, 0,
-                         0, -1, 0, 0, 0, 0, 1);
+    cv::Mat transform = cv::Mat::eye(4, 4, CV_64F);
+    transform.at<double>(1, 1) = -1.0;
+    transform.at<double>(2, 2) = -1.0;
     camera_pose_matrix_gt = transform * camera_pose_matrix_gt * transform;
 
     double fx_gt = camera_matrix_gt.at<double>(0, 0);

--- a/tests/test_calibration.cpp
+++ b/tests/test_calibration.cpp
@@ -4,8 +4,8 @@
 #include <stdio.h>
 
 #include <boost/test/unit_test.hpp>
-#include <opencv_compat.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv_compat.hpp>
 
 #include <McCalib.hpp>
 


### PR DESCRIPTION
Upgrading to OpenCV v5.0.0

Observed calibration quality improvements are likely driven by the new ChArUco detection path in OpenCV 5, with a runtime tradeoff.

Scenario | OpenCV 5 Reprojection Error | OpenCV 5 Calibration Time (s) | OpenCV 4.11 Reprojection Error | OpenCV 4.11 Calibration Time (s)
-- | -- | -- | -- | --
calib_param_synth_Scenario1.yml | 0.022278 | 59 | 0.0518725 | 34
calib_param_synth_Scenario2.yml | 0.0291427 | 16 | 0.0516786 | 21
calib_param_synth_Scenario3.yml | 0.0155722 | 224 | 0.0397111 | 101
calib_param_synth_Scenario4.yml | 0.018662 | 164 | 0.0420338 | 83
calib_param_synth_Scenario5.yml | 0.0662857 | 221 | 0.0950941 | 118

